### PR TITLE
Add minimal combat-only environment

### DIFF
--- a/src/sts_ironclad_rl/__init__.py
+++ b/src/sts_ironclad_rl/__init__.py
@@ -2,22 +2,30 @@
 
 from .bootstrap import ProjectInfo, get_project_info
 from .env import (
+    Action,
     CombatantState,
+    CombatEnvironment,
     CombatState,
     DrawResult,
     EncounterConfig,
+    InvalidActionError,
     PileState,
+    StepResult,
     create_initial_combat_state,
     draw_cards,
 )
 
 __all__ = [
+    "Action",
     "CombatState",
     "CombatantState",
+    "CombatEnvironment",
     "DrawResult",
     "EncounterConfig",
+    "InvalidActionError",
     "PileState",
     "ProjectInfo",
+    "StepResult",
     "create_initial_combat_state",
     "draw_cards",
     "get_project_info",

--- a/src/sts_ironclad_rl/env/__init__.py
+++ b/src/sts_ironclad_rl/env/__init__.py
@@ -1,5 +1,6 @@
 """Environment state primitives for the Slay the Spire RL stack."""
 
+from .combat import Action, CombatEnvironment, InvalidActionError, StepResult
 from .state import (
     CombatantState,
     CombatState,
@@ -11,11 +12,15 @@ from .state import (
 )
 
 __all__ = [
+    "Action",
     "CombatState",
     "CombatantState",
+    "CombatEnvironment",
     "DrawResult",
     "EncounterConfig",
+    "InvalidActionError",
     "PileState",
+    "StepResult",
     "create_initial_combat_state",
     "draw_cards",
 ]

--- a/src/sts_ironclad_rl/env/combat.py
+++ b/src/sts_ironclad_rl/env/combat.py
@@ -1,0 +1,174 @@
+"""Minimal combat-only environment with deterministic transitions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from .state import (
+    CombatantState,
+    CombatState,
+    EncounterConfig,
+    PileState,
+    create_initial_combat_state,
+    draw_cards,
+)
+
+
+class Action(StrEnum):
+    """Minimal action set for the first combat environment slice."""
+
+    ATTACK = "attack"
+    DEFEND = "defend"
+    END_TURN = "end_turn"
+
+
+@dataclass(frozen=True)
+class StepResult:
+    """Result of a single environment transition."""
+
+    state: CombatState
+    reward: float
+    done: bool
+
+
+class InvalidActionError(ValueError):
+    """Raised when a chosen action is not currently legal."""
+
+
+class CombatEnvironment:
+    """Single-encounter deterministic combat environment."""
+
+    def __init__(self, config: EncounterConfig) -> None:
+        self._config = config
+        self._state: CombatState | None = None
+
+    def reset(self, seed: int) -> CombatState:
+        """Reset the encounter from a deterministic seed."""
+        self._state = create_initial_combat_state(seed=seed, config=self._config)
+        return self._state
+
+    def action_mask(self) -> dict[Action, bool]:
+        """Return which actions are legal in the current state."""
+        state = self._require_state()
+        return {
+            Action.ATTACK: state.energy > 0 and "strike" in state.piles.hand,
+            Action.DEFEND: state.energy > 0 and "defend" in state.piles.hand,
+            Action.END_TURN: True,
+        }
+
+    def step(self, action: Action) -> StepResult:
+        """Apply one action and advance the combat deterministically."""
+        state = self._require_state()
+        if not self.action_mask()[action]:
+            msg = f"illegal action: {action}"
+            raise InvalidActionError(msg)
+
+        next_state = state
+        reward = 0.0
+
+        if action is Action.ATTACK:
+            next_state = _play_card(next_state, card_id="strike", block_gain=0, enemy_damage=6)
+            reward = 6.0
+        elif action is Action.DEFEND:
+            next_state = _play_card(next_state, card_id="defend", block_gain=5, enemy_damage=0)
+        else:
+            next_state = _end_turn(next_state)
+
+        done = next_state.enemy.hp == 0 or next_state.player.hp == 0
+        self._state = next_state
+        return StepResult(state=next_state, reward=reward, done=done)
+
+    def _require_state(self) -> CombatState:
+        if self._state is None:
+            msg = "environment must be reset before use"
+            raise RuntimeError(msg)
+        return self._state
+
+
+def _play_card(state: CombatState, card_id: str, block_gain: int, enemy_damage: int) -> CombatState:
+    hand = list(state.piles.hand)
+    hand.remove(card_id)
+
+    next_enemy_hp = max(0, state.enemy.hp - enemy_damage)
+    next_player = CombatantState(
+        hp=state.player.hp,
+        max_hp=state.player.max_hp,
+        block=state.player.block + block_gain,
+    )
+    next_enemy = CombatantState(
+        hp=next_enemy_hp,
+        max_hp=state.enemy.max_hp,
+        block=state.enemy.block,
+    )
+    next_piles = PileState(
+        draw_pile=state.piles.draw_pile,
+        hand=tuple(hand),
+        discard_pile=state.piles.discard_pile + (card_id,),
+        exhaust_pile=state.piles.exhaust_pile,
+    )
+    return CombatState(
+        seed=state.seed,
+        turn=state.turn,
+        energy=state.energy - 1,
+        draw_per_turn=state.draw_per_turn,
+        player=next_player,
+        enemy=next_enemy,
+        piles=next_piles,
+    )
+
+
+def _end_turn(state: CombatState) -> CombatState:
+    post_enemy = _apply_enemy_turn(state)
+    refreshed_piles = _discard_hand(post_enemy.piles)
+    start_turn = CombatState(
+        seed=post_enemy.seed,
+        turn=post_enemy.turn + 1,
+        energy=3,
+        draw_per_turn=post_enemy.draw_per_turn,
+        player=CombatantState(
+            hp=post_enemy.player.hp,
+            max_hp=post_enemy.player.max_hp,
+            block=0,
+        ),
+        enemy=post_enemy.enemy,
+        piles=refreshed_piles,
+    )
+    return draw_cards(start_turn, start_turn.draw_per_turn).state
+
+
+def _apply_enemy_turn(state: CombatState) -> CombatState:
+    damage = _enemy_damage(seed=state.seed, turn=state.turn)
+    prevented = min(state.player.block, damage)
+    next_player = CombatantState(
+        hp=max(0, state.player.hp - (damage - prevented)),
+        max_hp=state.player.max_hp,
+        block=state.player.block - prevented,
+    )
+    return CombatState(
+        seed=state.seed,
+        turn=state.turn,
+        energy=state.energy,
+        draw_per_turn=state.draw_per_turn,
+        player=next_player,
+        enemy=state.enemy,
+        piles=state.piles,
+    )
+
+
+def _discard_hand(piles: PileState) -> PileState:
+    draw_pile = piles.draw_pile
+    discard_pile = piles.discard_pile + piles.hand
+    if not draw_pile and discard_pile:
+        draw_pile = discard_pile
+        discard_pile = ()
+    return PileState(
+        draw_pile=draw_pile,
+        hand=(),
+        discard_pile=discard_pile,
+        exhaust_pile=piles.exhaust_pile,
+    )
+
+
+def _enemy_damage(seed: int, turn: int) -> int:
+    return 6 + ((seed + turn) % 2)

--- a/src/sts_ironclad_rl/env/state.py
+++ b/src/sts_ironclad_rl/env/state.py
@@ -82,6 +82,7 @@ class CombatState:
     seed: int
     turn: int
     energy: int
+    draw_per_turn: int
     player: CombatantState
     enemy: CombatantState
     piles: PileState
@@ -103,6 +104,7 @@ def create_initial_combat_state(seed: int, config: EncounterConfig) -> CombatSta
         seed=seed,
         turn=1,
         energy=config.starting_energy,
+        draw_per_turn=config.draw_per_turn,
         player=CombatantState(hp=config.player_max_hp, max_hp=config.player_max_hp),
         enemy=CombatantState(hp=config.enemy_max_hp, max_hp=config.enemy_max_hp),
         piles=piles,
@@ -129,6 +131,7 @@ def draw_cards(state: CombatState, count: int) -> DrawResult:
         seed=state.seed,
         turn=state.turn,
         energy=state.energy,
+        draw_per_turn=state.draw_per_turn,
         player=state.player,
         enemy=state.enemy,
         piles=next_piles,

--- a/tests/test_combat_env.py
+++ b/tests/test_combat_env.py
@@ -1,0 +1,82 @@
+from sts_ironclad_rl import Action, CombatEnvironment, EncounterConfig, InvalidActionError
+
+
+def make_config() -> EncounterConfig:
+    return EncounterConfig(
+        player_max_hp=80,
+        enemy_max_hp=20,
+        starting_energy=3,
+        draw_per_turn=5,
+        deck=("strike", "strike", "strike", "defend", "defend"),
+    )
+
+
+def test_reset_is_deterministic_for_same_seed() -> None:
+    env_a = CombatEnvironment(make_config())
+    env_b = CombatEnvironment(make_config())
+
+    state_a = env_a.reset(seed=13)
+    state_b = env_b.reset(seed=13)
+
+    assert state_a == state_b
+
+
+def test_invalid_action_is_rejected_when_card_not_in_hand() -> None:
+    env = CombatEnvironment(
+        EncounterConfig(
+            player_max_hp=80,
+            enemy_max_hp=20,
+            starting_energy=3,
+            draw_per_turn=1,
+            deck=("strike",),
+        )
+    )
+    env.reset(seed=1)
+
+    try:
+        env.step(Action.DEFEND)
+    except InvalidActionError as exc:
+        assert "illegal action" in str(exc)
+    else:
+        raise AssertionError("expected illegal action to raise InvalidActionError")
+
+
+def test_action_mask_reflects_energy_and_hand() -> None:
+    env = CombatEnvironment(make_config())
+    env.reset(seed=13)
+
+    first_state = env.step(Action.ATTACK).state
+    second_state = env.step(Action.ATTACK).state
+    third_state = env.step(Action.ATTACK).state
+
+    assert first_state.energy == 2
+    assert second_state.energy == 1
+    assert third_state.energy == 0
+    assert env.action_mask()[Action.ATTACK] is False
+    assert env.action_mask()[Action.DEFEND] is False
+    assert env.action_mask()[Action.END_TURN] is True
+
+
+def test_short_rollout_completes_deterministically() -> None:
+    env = CombatEnvironment(make_config())
+    env.reset(seed=5)
+
+    rewards: list[float] = []
+    actions = [
+        Action.ATTACK,
+        Action.ATTACK,
+        Action.END_TURN,
+        Action.ATTACK,
+        Action.ATTACK,
+    ]
+
+    done = False
+    for action in actions:
+        result = env.step(action)
+        rewards.append(result.reward)
+        done = result.done
+        if done:
+            break
+
+    assert rewards == [6.0, 6.0, 0.0, 6.0, 6.0]
+    assert done is True


### PR DESCRIPTION
## Summary

- add a minimal deterministic combat environment with , , and 
- implement a narrow action set with invalid-action rejection and deterministic enemy damage
- add smoke tests for repeatable resets, masking behavior, and a short combat rollout

## Issue link

- Refs #5

## Checks

- [x] 11 files left unchanged
- [x] All checks passed!
- [x] .........                                                                [100%]
9 passed in 0.01s

## Risks and impact

- the environment is intentionally simplified around a tiny action/card model, so later card and encounter work will change behavior substantially
- stacked on #2 by design to keep the diff reviewable

## Follow-up work

- baseline bots and broader combat mechanics