### PR TITLE
Add developer tooling and local workflow

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+repos:
+  - repo: local
+    hooks:
+      - id: ruff-format
+        name: ruff format
+        entry: ruff format --check .
+        language: system
+        pass_filenames: false
+      - id: ruff-check
+        name: ruff check
+        entry: ruff check .
+        language: system
+        pass_filenames: false
+      - id: pytest
+        name: pytest
+        entry: pytest -q
+        language: system
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ pip install -r requirements.txt
 pre-commit install
 ```
 
+## Local workflow
+
+Run the same checks locally before opening a PR:
+
+```bash
+pre-commit run --all-files
+```
+
 ### Commands
 
 ```bash
@@ -37,3 +45,8 @@ ruff check .
 pytest -q
 ```
 
+Pre-commit runs:
+
+- `ruff format --check .`
+- `ruff check .`
+- `pytest -q`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,3 +27,6 @@ line-length = 100
 
 [tool.ruff.lint]
 select = ["E", "F", "I"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["sts_ironclad_rl"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 -e .
+pre-commit
 pytest
 ruff


### PR DESCRIPTION
Closes #8

## Summary of changes
- add a local `.pre-commit-config.yaml` that runs format, lint, and tests
- add `pre-commit` to the developer requirements
- document the local pre-commit workflow and the exact commands it runs in the README
- add Ruff first-party import classification for the project package

## Tests run
- `ruff format --check .`
- `ruff check .`
- `pytest -q`
- `PRE_COMMIT_HOME=/tmp/pre-commit-cache python3.12 -m pre_commit run --all-files`

## Risks or follow-up items
- local verification currently depends on a Python 3.11+ interpreter being available in the developer environment
- CI still runs the underlying commands directly rather than `pre-commit`; that can stay as-is unless we want CI to exercise the wrapper too