### PR TITLE
Add current milestone tracker doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ Reinforcement-learning research stack for Slay the Spire, starting with a combat
 - Milestone 3: evaluation suite
 - Milestone 4: learning pipeline
 
+## Current Focus
+
+- Active milestone tracker: [docs/current_milestone.md](docs/current_milestone.md)
+
 ## Project Structure
 
 - `AGENTS.md`: Rules, code standards, and workflow expectations for contributors and AI agents.

--- a/docs/current_milestone.md
+++ b/docs/current_milestone.md
@@ -1,0 +1,25 @@
+# Current Milestone
+
+This document tracks the currently active milestone so contributors do not have
+to rely on chat history or local agent memory.
+
+## Active Focus
+
+Milestone 1 - Live Game Bridge
+
+This is the current working focus even though the long-term roadmap in
+`docs/roadmap.md` still describes milestone 1 as the combat-only environment.
+
+## Goal
+
+Connect to Slay the Spire using CommunicationMod and read game state.
+
+## Tasks
+
+- connect Python bridge
+- print combat state
+- log trajectory
+
+## Success Criteria
+
+Python script can read state and perform one legal action.


### PR DESCRIPTION
Closes #13

## Summary of changes
- add `docs/current_milestone.md` as the repo-tracked record of the active milestone
- link the current milestone tracker from the README
- explicitly distinguish the active focus from the longer-term roadmap so contributors do not confuse the two

## Tests run
- `ruff format --check .`
- `ruff check .`
- `pytest -q`

## Risks or follow-up items
- the roadmap and active milestone tracker now intentionally diverge; if the live game bridge becomes the formal milestone 1 plan, `docs/roadmap.md` should be updated in a follow-up PR
- this file is only useful if it is kept current as priorities change