### PR TITLE
Create base package layout for env, agents, training, evaluation, and utils

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,10 +4,11 @@ This document outlines the intended high-level architecture for the project.
 
 ### Top-Level Layout
 
-- `src/env/`: Environment wrappers and interfaces for *Slay the Spire*.
-- `src/agents/`: Policy and value function implementations.
-- `src/training/`: Training loops, replay buffers, and optimization logic.
-- `src/utils/`: Shared utilities (logging, seeding, metrics, etc.).
+- `src/sts_ironclad_rl/env/`: Environment wrappers and interfaces for *Slay the Spire*.
+- `src/sts_ironclad_rl/agents/`: Policy and value function implementations.
+- `src/sts_ironclad_rl/training/`: Training loops, replay buffers, and optimization logic.
+- `src/sts_ironclad_rl/evaluation/`: Evaluation harnesses, benchmarks, and reporting helpers.
+- `src/sts_ironclad_rl/utils/`: Shared utilities (logging, seeding, metrics, etc.).
 
 ### Current Environment Foundation
 

--- a/src/sts_ironclad_rl/agents/__init__.py
+++ b/src/sts_ironclad_rl/agents/__init__.py
@@ -1,0 +1,3 @@
+"""Agent implementations for the Slay the Spire RL stack."""
+
+__all__: list[str] = []

--- a/src/sts_ironclad_rl/evaluation/__init__.py
+++ b/src/sts_ironclad_rl/evaluation/__init__.py
@@ -1,0 +1,3 @@
+"""Evaluation tooling for the Slay the Spire RL stack."""
+
+__all__: list[str] = []

--- a/src/sts_ironclad_rl/training/__init__.py
+++ b/src/sts_ironclad_rl/training/__init__.py
@@ -1,0 +1,3 @@
+"""Training loops and learning utilities for the Slay the Spire RL stack."""
+
+__all__: list[str] = []

--- a/src/sts_ironclad_rl/utils/__init__.py
+++ b/src/sts_ironclad_rl/utils/__init__.py
@@ -1,0 +1,3 @@
+"""Shared utilities for the Slay the Spire RL stack."""
+
+__all__: list[str] = []

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,4 +1,11 @@
-from sts_ironclad_rl import __version__, get_project_info
+from sts_ironclad_rl import (
+    __version__,
+    agents,
+    evaluation,
+    get_project_info,
+    training,
+    utils,
+)
 
 
 def test_package_metadata_smoke() -> None:
@@ -7,3 +14,10 @@ def test_package_metadata_smoke() -> None:
     assert __version__ == "0.1.0"
     assert info.name == "sts-ironclad-rl"
     assert info.supports_deterministic_seeds is True
+
+
+def test_package_layout_smoke() -> None:
+    assert agents.__name__ == "sts_ironclad_rl.agents"
+    assert training.__name__ == "sts_ironclad_rl.training"
+    assert evaluation.__name__ == "sts_ironclad_rl.evaluation"
+    assert utils.__name__ == "sts_ironclad_rl.utils"


### PR DESCRIPTION
Closes #7

## Summary of changes
- add the missing agents, training, evaluation, and utils package modules under src/sts_ironclad_rl
- extend the bootstrap smoke test to assert the new package layout imports cleanly
- update the architecture doc so the documented package paths match the actual src/sts_ironclad_rl/... layout

## Tests run
- ruff format .
- ruff check .
- pytest -q

## Risks or follow-up items
- the new packages are intentionally placeholders; they establish import boundaries but do not yet include concrete agent, training, evaluation, or utility implementations
- the repository still has open Milestone 0 PRs for local workflow tooling (#12) and the current milestone tracker (#14), so main will not reflect full Milestone 0 scope until those merge