### PR TITLE
Freeze learner contract for masked DQN

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ milestone.
 - Live-game bridge plan: [docs/live_game_bridge.md](docs/live_game_bridge.md)
 - PR reconciliation and next workstreams: [docs/live_game_first_milestone.md](docs/live_game_first_milestone.md)
 - Live collection scaffold: [docs/live_training_scaffold.md](docs/live_training_scaffold.md)
+- Learner-side DQN contract: [docs/learner_contract.md](docs/learner_contract.md)
 
 ## Project Structure
 

--- a/docs/learner_contract.md
+++ b/docs/learner_contract.md
@@ -1,0 +1,148 @@
+## Learner Contract
+
+This document freezes the training-facing interface that future masked-DQN code
+should consume. It is built on top of the existing live rollout path and does
+not introduce a second execution loop.
+
+All defaults below come from
+[`sts_ironclad_rl.training.learner`](/Users/lucacc/Desktop/STS/STS-Ironclad-RL/src/sts_ironclad_rl/training/learner.py).
+
+## Observation Vector
+
+Default observation layout:
+
+- `MAX_HAND_SLOTS = 10`
+- `MAX_ENEMIES = 5`
+- `vector_size = 93`
+- schema version: `learner_observation.v1`
+
+Feature ordering is fixed and deterministic:
+
+1. `player_hp`
+2. `player_max_hp`
+3. `player_block`
+4. `player_energy`
+5. `draw_pile_size`
+6. `discard_pile_size`
+7. `exhaust_pile_size`
+8. `turn_index`
+9. `hand_mask_0 .. hand_mask_9`
+10. `hand_0_card_token, hand_0_cost, hand_0_is_playable, hand_0_has_target`
+11. `hand_1_*`
+12. `...`
+13. `hand_9_*`
+14. `enemy_mask_0 .. enemy_mask_4`
+15. `enemy_0_current_hp, enemy_0_max_hp, enemy_0_block, enemy_0_intent_token, enemy_0_alive, enemy_0_targetable`
+16. `enemy_1_*`
+17. `...`
+18. `enemy_4_*`
+
+Padding and truncation rules:
+
+- Hand cards are kept in bridge order and truncated to the first 10 cards.
+- Enemies are kept in bridge order and truncated to the first 5 enemies.
+- `hand_mask_i = 1` when slot `i` is populated and `0` when the slot is padded.
+- `enemy_mask_i = 1` when slot `i` is populated and `0` when the slot is padded.
+- Dead enemies are still populated slots when present in the live snapshot. They
+  are not padding. Their `enemy_i_alive` feature is `0`.
+- Padded card and intent tokens use `0.0`.
+
+Categorical token fields:
+
+- `card_token` is a deterministic SHA-1 derived numeric token from the live
+  `card_id` when available, else the card name.
+- `intent_token` is a deterministic SHA-1 derived numeric token from the live
+  enemy intent string.
+
+## Action Index Space
+
+Default action layout:
+
+- `MAX_HAND_SLOTS = 10`
+- `MAX_ENEMIES = 5`
+- `action_space_size = 61`
+
+Index mapping:
+
+- `0 -> END_TURN`
+- `1 .. 10 -> PLAY_CARD_HAND_i_NO_TARGET` for hand slots `0 .. 9`
+- `11 .. 60 -> PLAY_CARD_HAND_i_TARGET_ENEMY_j` in row-major order:
+  `11 + i * MAX_ENEMIES + j`
+
+Examples:
+
+- `1 -> PLAY_CARD_HAND_0_NO_TARGET`
+- `10 -> PLAY_CARD_HAND_9_NO_TARGET`
+- `11 -> PLAY_CARD_HAND_0_TARGET_ENEMY_0`
+- `15 -> PLAY_CARD_HAND_0_TARGET_ENEMY_4`
+- `16 -> PLAY_CARD_HAND_1_TARGET_ENEMY_0`
+
+Out-of-bounds behavior:
+
+- Cards beyond the first 10 hand slots are not representable in the learner
+  action space.
+- Enemies beyond the first 5 slots are not representable in the learner action
+  space.
+- Replay extraction raises if a stored action references an out-of-bounds hand
+  or enemy index.
+
+## Legal Action Mask
+
+The legal mask length is always `61` and aligns exactly with the action index
+ordering above.
+
+Mask semantics:
+
+- `1` means the learner action index is legal for that snapshot.
+- `0` means it is illegal.
+- `END_TURN` is marked legal for combat snapshots.
+- Play-card legality is inherited from the existing live action contract:
+  `is_playable`, target requirements, targetability, and any live-side energy
+  constraints already reflected by `is_playable`.
+- Unrepresentable actions outside the learner bounds are dropped from the mask.
+
+Within extracted learner transitions, `mask` is the legal mask for `s'`
+(`next_state`). That is the mask needed for masked-DQN bootstrap targets.
+
+## Reward Function
+
+Default shaped reward:
+
+```text
+reward =
+  + 0.1 * max(0, enemy_hp(s) - enemy_hp(s'))
+  - 0.2 * max(0, player_hp(s) - player_hp(s'))
+  - 0.01
+  + 1.0 if terminal victory
+  - 1.0 if terminal defeat
+```
+
+`combat_end` terminal states do not receive an extra terminal bonus.
+
+All reward weights live in `RewardConfig` and can be changed without changing
+the transition schema.
+
+## Transition Schema
+
+`LearnerTransition` stores:
+
+- `state`: learner observation vector for `s`
+- `action_index`: discrete learner action index for `a`
+- `reward`: shaped scalar reward
+- `next_state`: learner observation vector for `s'`
+- `done`: terminal flag
+- `mask`: legal action mask for `s'`
+
+`LearnerTransition.as_tuple()` returns:
+
+```text
+(s, a, r, s', done, mask)
+```
+
+Replay extraction rules:
+
+- One transition is emitted for each replay entry that contains an action and is
+  followed by another replay entry.
+- Terminal-only replay entries do not emit transitions by themselves.
+- The extractor consumes the same replay entries produced by the shared live
+  rollout path.

--- a/src/sts_ironclad_rl/training/__init__.py
+++ b/src/sts_ironclad_rl/training/__init__.py
@@ -9,6 +9,18 @@ from .artifacts import (
     slugify,
 )
 from .experiments import ExperimentRunner, ExperimentRunResult, PolicyProvider
+from .learner import (
+    LEARNER_OBSERVATION_SCHEMA_VERSION,
+    LEARNER_TRANSITION_SCHEMA_VERSION,
+    LearnerActionIndex,
+    LearnerObservation,
+    LearnerObservationEncoder,
+    LearnerObservationLayout,
+    LearnerRewardFunction,
+    LearnerTransition,
+    LearnerTransitionExtractor,
+    RewardConfig,
+)
 from .specs import ExperimentSpec, load_experiment_spec
 
 __all__ = [
@@ -17,7 +29,17 @@ __all__ = [
     "ExperimentRunResult",
     "ExperimentRunner",
     "ExperimentSpec",
+    "LEARNER_OBSERVATION_SCHEMA_VERSION",
+    "LEARNER_TRANSITION_SCHEMA_VERSION",
+    "LearnerActionIndex",
+    "LearnerObservation",
+    "LearnerObservationEncoder",
+    "LearnerObservationLayout",
+    "LearnerRewardFunction",
+    "LearnerTransition",
+    "LearnerTransitionExtractor",
     "PolicyProvider",
+    "RewardConfig",
     "RunMetadata",
     "build_run_id",
     "load_experiment_spec",

--- a/src/sts_ironclad_rl/training/learner.py
+++ b/src/sts_ironclad_rl/training/learner.py
@@ -1,0 +1,464 @@
+"""Learner-facing contracts built on top of the shared live rollout path."""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass, field
+from typing import TypeAlias
+
+from ..integration import GameStateSnapshot
+from ..live import (
+    ActionDecision,
+    BridgeObservationEncoder,
+    EncodedObservation,
+    EndTurnAction,
+    LiveObservation,
+    MonsterTarget,
+    ObservationLayout,
+    PlayCardAction,
+    ReplayEntry,
+    action_from_id,
+)
+
+LEARNER_OBSERVATION_SCHEMA_VERSION = "learner_observation.v1"
+LEARNER_TRANSITION_SCHEMA_VERSION = "learner_transition.v1"
+PAD_TOKEN_VALUE = 0.0
+
+ObservationSource: TypeAlias = (
+    GameStateSnapshot | EncodedObservation | ReplayEntry | LiveObservation
+)
+
+
+@dataclass(frozen=True)
+class LearnerObservationLayout:
+    """Fixed observation layout consumed by learning code."""
+
+    max_hand_slots: int = ObservationLayout().max_hand_cards
+    max_enemies: int = ObservationLayout().max_enemies
+
+    @property
+    def player_feature_names(self) -> tuple[str, ...]:
+        return ("player_hp", "player_max_hp", "player_block", "player_energy")
+
+    @property
+    def combat_context_feature_names(self) -> tuple[str, ...]:
+        return ("draw_pile_size", "discard_pile_size", "exhaust_pile_size", "turn_index")
+
+    @property
+    def hand_slot_feature_names(self) -> tuple[str, ...]:
+        return ("card_token", "cost", "is_playable", "has_target")
+
+    @property
+    def enemy_slot_feature_names(self) -> tuple[str, ...]:
+        return ("current_hp", "max_hp", "block", "intent_token", "alive", "targetable")
+
+    @property
+    def vector_size(self) -> int:
+        return len(self.feature_names())
+
+    def feature_names(self) -> tuple[str, ...]:
+        names = list(self.player_feature_names)
+        names.extend(self.combat_context_feature_names)
+        names.extend(f"hand_mask_{slot}" for slot in range(self.max_hand_slots))
+        for slot in range(self.max_hand_slots):
+            names.extend(
+                f"hand_{slot}_{feature_name}" for feature_name in self.hand_slot_feature_names
+            )
+        names.extend(f"enemy_mask_{slot}" for slot in range(self.max_enemies))
+        for slot in range(self.max_enemies):
+            names.extend(
+                f"enemy_{slot}_{feature_name}" for feature_name in self.enemy_slot_feature_names
+            )
+        return tuple(names)
+
+
+@dataclass(frozen=True)
+class LearnerObservation:
+    """Fixed-size learner observation vector plus section masks."""
+
+    schema_version: str
+    vector: tuple[float, ...]
+    hand_mask: tuple[int, ...]
+    enemy_mask: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class LearnerActionIndex:
+    """Stable discrete action indexing for combat-only learning."""
+
+    max_hand_slots: int = ObservationLayout().max_hand_cards
+    max_enemies: int = ObservationLayout().max_enemies
+
+    @property
+    def size(self) -> int:
+        return 1 + self.max_hand_slots + (self.max_hand_slots * self.max_enemies)
+
+    def describe(self, action_index: int) -> str:
+        if action_index == 0:
+            return "END_TURN"
+
+        hand_start = 1
+        targeted_start = hand_start + self.max_hand_slots
+        if hand_start <= action_index < targeted_start:
+            return f"PLAY_CARD_HAND_{action_index - hand_start}_NO_TARGET"
+        if targeted_start <= action_index < self.size:
+            offset = action_index - targeted_start
+            hand_index, enemy_index = divmod(offset, self.max_enemies)
+            return f"PLAY_CARD_HAND_{hand_index}_TARGET_ENEMY_{enemy_index}"
+
+        msg = f"action_index out of range: {action_index}"
+        raise ValueError(msg)
+
+    def index_to_action_id(self, action_index: int) -> str:
+        if action_index == 0:
+            return EndTurnAction().action_id
+
+        hand_start = 1
+        targeted_start = hand_start + self.max_hand_slots
+        if hand_start <= action_index < targeted_start:
+            return PlayCardAction(hand_index=action_index - hand_start).action_id
+        if targeted_start <= action_index < self.size:
+            offset = action_index - targeted_start
+            hand_index, enemy_index = divmod(offset, self.max_enemies)
+            return PlayCardAction(
+                hand_index=hand_index,
+                target=MonsterTarget(enemy_index),
+            ).action_id
+
+        msg = f"action_index out of range: {action_index}"
+        raise ValueError(msg)
+
+    def action_to_index(self, action: str | ActionDecision) -> int:
+        action_id = action.action_id if isinstance(action, ActionDecision) else action
+        parsed_action = action_from_id(action_id)
+
+        if isinstance(parsed_action, EndTurnAction):
+            return 0
+        if not isinstance(parsed_action, PlayCardAction):
+            msg = f"unsupported learner action: {action_id}"
+            raise ValueError(msg)
+        if parsed_action.hand_index >= self.max_hand_slots:
+            msg = f"hand_index exceeds learner bounds: {parsed_action.hand_index}"
+            raise ValueError(msg)
+        if parsed_action.target is None:
+            return 1 + parsed_action.hand_index
+        if parsed_action.target.monster_index >= self.max_enemies:
+            msg = f"monster_index exceeds learner bounds: {parsed_action.target.monster_index}"
+            raise ValueError(msg)
+        return (
+            1
+            + self.max_hand_slots
+            + (parsed_action.hand_index * self.max_enemies)
+            + parsed_action.target.monster_index
+        )
+
+    def legal_mask(self, source: ObservationSource) -> tuple[int, ...]:
+        if isinstance(source, LiveObservation):
+            msg = "legal_mask requires a snapshot-backed source"
+            raise TypeError(msg)
+
+        snapshot = _snapshot_from_source(source)
+        mask = [0] * self.size
+        if snapshot.in_combat:
+            mask[0] = 1
+
+        for action_id in BridgeObservationEncoder().action_contract.legal_action_ids(snapshot):
+            try:
+                mask[self.action_to_index(action_id)] = 1
+            except ValueError:
+                continue
+        return tuple(mask)
+
+
+@dataclass(frozen=True)
+class RewardConfig:
+    """Configurable shaped reward weights for learner transitions."""
+
+    enemy_hp_weight: float = 0.1
+    player_hp_weight: float = 0.2
+    terminal_win_bonus: float = 1.0
+    terminal_loss_penalty: float = 1.0
+    step_penalty: float = 0.01
+
+
+@dataclass(frozen=True)
+class LearnerRewardFunction:
+    """Compute shaped combat rewards from adjacent live observations."""
+
+    config: RewardConfig = field(default_factory=RewardConfig)
+    observation_encoder: "LearnerObservationEncoder" = field(
+        default_factory=lambda: LearnerObservationEncoder()
+    )
+
+    def reward(
+        self,
+        current: ObservationSource,
+        nxt: ObservationSource,
+        *,
+        done: bool,
+        outcome: str | None,
+    ) -> float:
+        current_live = self.observation_encoder.live_observation(current)
+        next_live = self.observation_encoder.live_observation(nxt)
+
+        next_enemy_hp = _resolved_next_enemy_hp(
+            current_observation=current_live,
+            next_observation=next_live,
+            done=done,
+            outcome=outcome,
+        )
+        next_player_hp = _resolved_next_player_hp(
+            current_observation=current_live,
+            next_observation=next_live,
+            done=done,
+            outcome=outcome,
+        )
+        enemy_hp_delta = max(0, _enemy_hp_total(current_live) - next_enemy_hp)
+        player_hp_delta = max(0, _player_hp(current_live) - next_player_hp)
+
+        reward = (enemy_hp_delta * self.config.enemy_hp_weight) - (
+            player_hp_delta * self.config.player_hp_weight
+        )
+        reward -= self.config.step_penalty
+
+        if done and outcome == "victory":
+            reward += self.config.terminal_win_bonus
+        elif done and outcome == "defeat":
+            reward -= self.config.terminal_loss_penalty
+
+        return reward
+
+
+@dataclass(frozen=True)
+class LearnerTransition:
+    """Replay-derived learner transition tuple for masked DQN training."""
+
+    schema_version: str
+    state: tuple[float, ...]
+    action_index: int
+    reward: float
+    next_state: tuple[float, ...]
+    done: bool
+    mask: tuple[int, ...]
+
+    def as_tuple(
+        self,
+    ) -> tuple[tuple[float, ...], int, float, tuple[float, ...], bool, tuple[int, ...]]:
+        return (self.state, self.action_index, self.reward, self.next_state, self.done, self.mask)
+
+
+@dataclass(frozen=True)
+class LearnerObservationEncoder:
+    """Convert live observations into a fixed learner vector."""
+
+    layout: LearnerObservationLayout = field(default_factory=LearnerObservationLayout)
+    bridge_encoder: BridgeObservationEncoder = field(default_factory=BridgeObservationEncoder)
+
+    def encode(self, source: ObservationSource) -> LearnerObservation:
+        live_observation = self.live_observation(source)
+        snapshot = (
+            _snapshot_from_source(source) if not isinstance(source, LiveObservation) else None
+        )
+        combat_state = {}
+        if snapshot is not None:
+            raw_combat_state = snapshot.raw_state.get("combat_state")
+            if isinstance(raw_combat_state, dict):
+                combat_state = raw_combat_state
+
+        combat = live_observation.combat
+        player_values = (
+            float(0 if combat is None else combat.player.current_hp),
+            float(0 if combat is None else combat.player.max_hp),
+            float(0 if combat is None else combat.player.block),
+            float(0 if combat is None else combat.player.energy),
+        )
+        context_values = (
+            float(_pile_size(combat_state, "draw_pile")),
+            float(_pile_size(combat_state, "discard_pile")),
+            float(_pile_size(combat_state, "exhaust_pile")),
+            float(0 if combat is None else combat.turn),
+        )
+
+        hand = () if combat is None else combat.hand[: self.layout.max_hand_slots]
+        hand_mask = tuple(
+            1 if slot < len(hand) else 0 for slot in range(self.layout.max_hand_slots)
+        )
+        hand_features: list[float] = []
+        for slot in range(self.layout.max_hand_slots):
+            if slot < len(hand):
+                card = hand[slot]
+                hand_features.extend(
+                    (
+                        _stable_token_value(card.card_id or card.name),
+                        float(card.cost),
+                        float(int(card.is_playable)),
+                        float(int(card.has_target)),
+                    )
+                )
+            else:
+                hand_features.extend((PAD_TOKEN_VALUE, 0.0, 0.0, 0.0))
+
+        enemies = () if combat is None else combat.enemies[: self.layout.max_enemies]
+        enemy_mask = tuple(
+            1 if slot < len(enemies) else 0 for slot in range(self.layout.max_enemies)
+        )
+        enemy_features: list[float] = []
+        for slot in range(self.layout.max_enemies):
+            if slot < len(enemies):
+                enemy = enemies[slot]
+                alive = int(enemy.current_hp > 0 and not enemy.is_gone and not enemy.half_dead)
+                enemy_features.extend(
+                    (
+                        float(enemy.current_hp),
+                        float(enemy.max_hp),
+                        float(enemy.block),
+                        _stable_token_value(enemy.intent),
+                        float(alive),
+                        float(int(enemy.is_targetable)),
+                    )
+                )
+            else:
+                enemy_features.extend((0.0, 0.0, 0.0, PAD_TOKEN_VALUE, 0.0, 0.0))
+
+        vector = tuple(
+            player_values
+            + context_values
+            + tuple(float(value) for value in hand_mask)
+            + tuple(hand_features)
+            + tuple(float(value) for value in enemy_mask)
+            + tuple(enemy_features)
+        )
+        return LearnerObservation(
+            schema_version=LEARNER_OBSERVATION_SCHEMA_VERSION,
+            vector=vector,
+            hand_mask=hand_mask,
+            enemy_mask=enemy_mask,
+        )
+
+    def live_observation(self, source: ObservationSource) -> LiveObservation:
+        if isinstance(source, LiveObservation):
+            return source
+        return self.bridge_encoder.parse(_snapshot_from_source(source))
+
+
+@dataclass(frozen=True)
+class LearnerTransitionExtractor:
+    """Build learner transitions from the shared replay records."""
+
+    observation_encoder: LearnerObservationEncoder = field(
+        default_factory=LearnerObservationEncoder
+    )
+    action_index: LearnerActionIndex = field(default_factory=LearnerActionIndex)
+    reward_function: LearnerRewardFunction = field(default_factory=LearnerRewardFunction)
+
+    def extract(self, entries: Sequence[ReplayEntry]) -> tuple[LearnerTransition, ...]:
+        transitions: list[LearnerTransition] = []
+        for current_entry, next_entry in zip(entries, entries[1:]):
+            if current_entry.action is None:
+                continue
+
+            state = self.observation_encoder.encode(current_entry.observation).vector
+            next_state = self.observation_encoder.encode(next_entry.observation).vector
+            done = bool(next_entry.terminal)
+            transitions.append(
+                LearnerTransition(
+                    schema_version=LEARNER_TRANSITION_SCHEMA_VERSION,
+                    state=state,
+                    action_index=self.action_index.action_to_index(current_entry.action),
+                    reward=self.reward_function.reward(
+                        current_entry.observation,
+                        next_entry.observation,
+                        done=done,
+                        outcome=next_entry.outcome,
+                    ),
+                    next_state=next_state,
+                    done=done,
+                    mask=self.action_index.legal_mask(next_entry.observation),
+                )
+            )
+        return tuple(transitions)
+
+    def extract_from_rollouts(
+        self,
+        episodes: Iterable[Sequence[ReplayEntry]],
+    ) -> tuple[LearnerTransition, ...]:
+        transitions: list[LearnerTransition] = []
+        for entries in episodes:
+            transitions.extend(self.extract(tuple(entries)))
+        return tuple(transitions)
+
+
+def _snapshot_from_source(
+    source: GameStateSnapshot | EncodedObservation | ReplayEntry,
+) -> GameStateSnapshot:
+    if isinstance(source, GameStateSnapshot):
+        return source
+    if isinstance(source, EncodedObservation):
+        return source.snapshot
+    if isinstance(source, ReplayEntry):
+        return source.observation.snapshot
+    msg = f"unsupported observation source: {type(source).__name__}"
+    raise TypeError(msg)
+
+
+def _pile_size(combat_state: dict[str, object], pile_name: str) -> int:
+    explicit_size = combat_state.get(f"{pile_name}_size")
+    if isinstance(explicit_size, bool):
+        return int(explicit_size)
+    if isinstance(explicit_size, int):
+        return explicit_size
+
+    pile = combat_state.get(pile_name)
+    if isinstance(pile, list):
+        return len(pile)
+    return 0
+
+
+def _stable_token_value(token: str | None) -> float:
+    if not token:
+        return PAD_TOKEN_VALUE
+    digest = hashlib.sha1(token.encode("utf-8")).hexdigest()
+    return float(int(digest[:8], 16))
+
+
+def _enemy_hp_total(observation: LiveObservation) -> int:
+    if observation.combat is None:
+        return 0
+    return sum(
+        max(0, enemy.current_hp) for enemy in observation.combat.enemies if not enemy.is_gone
+    )
+
+
+def _player_hp(observation: LiveObservation) -> int:
+    if observation.combat is None:
+        return 0
+    return max(0, observation.combat.player.current_hp)
+
+
+def _resolved_next_enemy_hp(
+    *,
+    current_observation: LiveObservation,
+    next_observation: LiveObservation,
+    done: bool,
+    outcome: str | None,
+) -> int:
+    if next_observation.combat is not None or not done:
+        return _enemy_hp_total(next_observation)
+    if outcome in {"victory", "combat_end"}:
+        return 0
+    return _enemy_hp_total(current_observation)
+
+
+def _resolved_next_player_hp(
+    *,
+    current_observation: LiveObservation,
+    next_observation: LiveObservation,
+    done: bool,
+    outcome: str | None,
+) -> int:
+    if next_observation.combat is not None or not done:
+        return _player_hp(next_observation)
+    if outcome == "defeat":
+        return 0
+    return _player_hp(current_observation)

--- a/tests/training/test_learner.py
+++ b/tests/training/test_learner.py
@@ -1,0 +1,357 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from sts_ironclad_rl.integration import GameStateSnapshot
+from sts_ironclad_rl.live import ActionDecision, BridgeObservationEncoder, ReplayEntry
+from sts_ironclad_rl.training import (
+    LEARNER_OBSERVATION_SCHEMA_VERSION,
+    LEARNER_TRANSITION_SCHEMA_VERSION,
+    LearnerActionIndex,
+    LearnerObservationEncoder,
+    LearnerRewardFunction,
+    LearnerTransitionExtractor,
+    RewardConfig,
+)
+
+
+def make_card(
+    *,
+    name: str,
+    card_id: str | None = None,
+    cost: int = 1,
+    is_playable: bool = True,
+    has_target: bool = False,
+) -> dict[str, Any]:
+    return {
+        "name": name,
+        "id": card_id or name.lower().replace(" ", "_"),
+        "cost": cost,
+        "is_playable": is_playable,
+        "has_target": has_target,
+    }
+
+
+def make_enemy(
+    *,
+    name: str = "Louse",
+    current_hp: int = 18,
+    max_hp: int | None = None,
+    block: int = 0,
+    intent: str | None = None,
+    is_gone: bool = False,
+    half_dead: bool = False,
+) -> dict[str, Any]:
+    return {
+        "name": name,
+        "id": name.lower().replace(" ", "_"),
+        "current_hp": current_hp,
+        "max_hp": current_hp if max_hp is None else max_hp,
+        "block": block,
+        "intent": intent,
+        "intent_base_damage": 0,
+        "intent_hits": 1,
+        "is_gone": is_gone,
+        "half_dead": half_dead,
+    }
+
+
+def make_combat_state(
+    *,
+    turn: int = 1,
+    player: dict[str, Any] | None = None,
+    hand: tuple[dict[str, Any], ...] = (),
+    monsters: tuple[dict[str, Any], ...] = (),
+) -> dict[str, Any]:
+    return {
+        "turn": turn,
+        "player": {
+            "current_hp": 70,
+            "max_hp": 80,
+            "block": 0,
+            "energy": 3,
+        }
+        if player is None
+        else dict(player),
+        "hand": [dict(card) for card in hand],
+        "monsters": [dict(monster) for monster in monsters],
+    }
+
+
+def make_snapshot(
+    *,
+    session_id: str = "session-1",
+    screen_state: str = "COMBAT",
+    available_actions: tuple[str, ...] = ("play", "end"),
+    in_combat: bool = True,
+    raw_state: dict[str, Any] | None = None,
+) -> GameStateSnapshot:
+    return GameStateSnapshot(
+        session_id=session_id,
+        screen_state=screen_state,
+        available_actions=available_actions,
+        in_combat=in_combat,
+        floor=3,
+        act=1,
+        raw_state={} if raw_state is None else dict(raw_state),
+    )
+
+
+def make_combat_snapshot(
+    *,
+    turn: int = 1,
+    player: dict[str, Any] | None = None,
+    hand: tuple[dict[str, Any], ...] = (),
+    monsters: tuple[dict[str, Any], ...] = (),
+    available_actions: tuple[str, ...] = ("play", "end"),
+) -> GameStateSnapshot:
+    return make_snapshot(
+        available_actions=available_actions,
+        in_combat=True,
+        raw_state={
+            "combat_state": make_combat_state(
+                turn=turn,
+                player=player,
+                hand=hand,
+                monsters=monsters,
+            )
+        },
+    )
+
+
+def encode_snapshot(snapshot: GameStateSnapshot):
+    return BridgeObservationEncoder().encode(snapshot)
+
+
+def test_learner_observation_encoder_emits_fixed_size_vector_with_padding_masks() -> None:
+    snapshot = make_snapshot(
+        available_actions=("play", "end"),
+        in_combat=True,
+        raw_state={
+            "combat_state": {
+                **make_combat_state(
+                    turn=7,
+                    player={"current_hp": 41, "max_hp": 80, "block": 12, "energy": 2},
+                    hand=(
+                        make_card(name="Bash", card_id="bash", cost=2, has_target=True),
+                        make_card(name="Defend", card_id="defend", cost=1, has_target=False),
+                    ),
+                    monsters=(
+                        make_enemy(name="Jaw Worm", current_hp=34, block=6, intent="ATTACK"),
+                        make_enemy(
+                            name="Cultist",
+                            current_hp=0,
+                            block=0,
+                            intent="BUFF",
+                            is_gone=False,
+                            half_dead=False,
+                        ),
+                    ),
+                ),
+                "draw_pile": [{}, {}, {}],
+                "discard_pile": [{}],
+                "exhaust_pile": [{}, {}],
+            }
+        },
+    )
+
+    encoder = LearnerObservationEncoder()
+    encoded = encoder.encode(snapshot)
+    feature_names = encoder.layout.feature_names()
+
+    assert encoded.schema_version == LEARNER_OBSERVATION_SCHEMA_VERSION
+    assert len(encoded.vector) == encoder.layout.vector_size == 93
+    assert len(feature_names) == 93
+    assert encoded.hand_mask == (1, 1, 0, 0, 0, 0, 0, 0, 0, 0)
+    assert encoded.enemy_mask == (1, 1, 0, 0, 0)
+
+    features = dict(zip(feature_names, encoded.vector, strict=True))
+    assert features["player_hp"] == 41.0
+    assert features["player_max_hp"] == 80.0
+    assert features["player_block"] == 12.0
+    assert features["player_energy"] == 2.0
+    assert features["draw_pile_size"] == 3.0
+    assert features["discard_pile_size"] == 1.0
+    assert features["exhaust_pile_size"] == 2.0
+    assert features["turn_index"] == 7.0
+    assert features["hand_0_cost"] == 2.0
+    assert features["hand_0_has_target"] == 1.0
+    assert features["hand_1_is_playable"] == 1.0
+    assert features["hand_2_card_token"] == 0.0
+    assert features["enemy_0_current_hp"] == 34.0
+    assert features["enemy_0_alive"] == 1.0
+    assert features["enemy_1_current_hp"] == 0.0
+    assert features["enemy_1_alive"] == 0.0
+    assert features["enemy_2_intent_token"] == 0.0
+
+
+def test_learner_action_index_has_stable_semantics() -> None:
+    action_index = LearnerActionIndex()
+
+    assert action_index.size == 61
+    assert action_index.describe(0) == "END_TURN"
+    assert action_index.describe(1) == "PLAY_CARD_HAND_0_NO_TARGET"
+    assert action_index.describe(10) == "PLAY_CARD_HAND_9_NO_TARGET"
+    assert action_index.describe(11) == "PLAY_CARD_HAND_0_TARGET_ENEMY_0"
+    assert action_index.describe(15) == "PLAY_CARD_HAND_0_TARGET_ENEMY_4"
+    assert action_index.describe(16) == "PLAY_CARD_HAND_1_TARGET_ENEMY_0"
+    assert action_index.action_to_index("end_turn") == 0
+    assert action_index.action_to_index("play_card:3") == 4
+    assert action_index.action_to_index("play_card:3:4") == 30
+    assert action_index.index_to_action_id(0) == "end_turn"
+    assert action_index.index_to_action_id(4) == "play_card:3"
+    assert action_index.index_to_action_id(30) == "play_card:3:4"
+
+
+def test_learner_action_mask_matches_index_order_and_filters_unrepresentable_actions() -> None:
+    snapshot = make_combat_snapshot(
+        hand=(
+            make_card(name="Strike", has_target=True, is_playable=True),
+            make_card(name="Burn", has_target=False, is_playable=False),
+            make_card(name="Defend", has_target=False, is_playable=True),
+        ),
+        monsters=(
+            make_enemy(name="Jaw Worm", current_hp=24),
+            make_enemy(name="Cultist", current_hp=0),
+        ),
+    )
+
+    action_index = LearnerActionIndex()
+    mask = action_index.legal_mask(snapshot)
+
+    assert len(mask) == action_index.size
+    assert mask[0] == 1
+    assert mask[action_index.action_to_index("play_card:0")] == 0
+    assert mask[action_index.action_to_index("play_card:0:0")] == 1
+    assert mask[action_index.action_to_index("play_card:1")] == 0
+    assert mask[action_index.action_to_index("play_card:2")] == 1
+
+
+def test_learner_reward_function_applies_hp_deltas_and_terminal_bonuses() -> None:
+    reward_function = LearnerRewardFunction(
+        config=RewardConfig(
+            enemy_hp_weight=0.1,
+            player_hp_weight=0.2,
+            terminal_win_bonus=1.0,
+            terminal_loss_penalty=2.0,
+            step_penalty=0.01,
+        )
+    )
+    current = make_combat_snapshot(
+        player={"current_hp": 50, "max_hp": 80, "block": 0, "energy": 3},
+        monsters=(make_enemy(name="Jaw Worm", current_hp=20),),
+    )
+    nxt = make_combat_snapshot(
+        player={"current_hp": 47, "max_hp": 80, "block": 0, "energy": 2},
+        monsters=(make_enemy(name="Jaw Worm", current_hp=12),),
+    )
+    terminal_victory = make_snapshot(
+        screen_state="MAP",
+        available_actions=("proceed",),
+        in_combat=False,
+        raw_state={"victory": True},
+    )
+    terminal_defeat = make_snapshot(
+        screen_state="DEATH",
+        available_actions=(),
+        in_combat=False,
+        raw_state={"player_dead": True},
+    )
+
+    assert reward_function.reward(current, nxt, done=False, outcome=None) == pytest.approx(0.19)
+    assert reward_function.reward(
+        nxt, terminal_victory, done=True, outcome="victory"
+    ) == pytest.approx(2.19)
+    assert reward_function.reward(
+        nxt, terminal_defeat, done=True, outcome="defeat"
+    ) == pytest.approx(-11.41)
+
+
+def test_transition_extractor_builds_replay_compatible_learning_tuples() -> None:
+    extractor = LearnerTransitionExtractor()
+    first_snapshot = make_combat_snapshot(
+        hand=(make_card(name="Strike", has_target=True),),
+        monsters=(make_enemy(name="Jaw Worm", current_hp=20),),
+    )
+    second_snapshot = make_combat_snapshot(
+        turn=2,
+        player={"current_hp": 77, "max_hp": 80, "block": 0, "energy": 1},
+        hand=(make_card(name="Defend", has_target=False),),
+        monsters=(make_enemy(name="Jaw Worm", current_hp=14),),
+    )
+    terminal_snapshot = make_snapshot(
+        screen_state="MAP",
+        available_actions=("proceed",),
+        in_combat=False,
+        raw_state={"victory": True},
+    )
+    entries = (
+        ReplayEntry(
+            session_id="session-1",
+            step_index=0,
+            observation=encode_snapshot(first_snapshot),
+            action=ActionDecision(action_id="play_card:0:0"),
+        ),
+        ReplayEntry(
+            session_id="session-1",
+            step_index=1,
+            observation=encode_snapshot(second_snapshot),
+            action=ActionDecision(action_id="play_card:0"),
+        ),
+        ReplayEntry(
+            session_id="session-1",
+            step_index=2,
+            observation=encode_snapshot(terminal_snapshot),
+            terminal=True,
+            outcome="victory",
+        ),
+    )
+
+    transitions = extractor.extract(entries)
+
+    assert len(transitions) == 2
+    assert all(
+        transition.schema_version == LEARNER_TRANSITION_SCHEMA_VERSION for transition in transitions
+    )
+    assert transitions[0].action_index == 11
+    assert transitions[0].done is False
+    assert transitions[0].mask[0] == 1
+    assert transitions[0].mask[extractor.action_index.action_to_index("play_card:0")] == 1
+    assert transitions[1].done is True
+    assert sum(transitions[1].mask) == 0
+    assert len(transitions[0].state) == extractor.observation_encoder.layout.vector_size
+    assert len(transitions[0].next_state) == extractor.observation_encoder.layout.vector_size
+    assert transitions[0].as_tuple()[1] == 11
+
+
+def test_transition_extractor_ignores_terminal_only_entries_without_actions() -> None:
+    terminal_snapshot = make_snapshot(
+        screen_state="MAP",
+        available_actions=("proceed",),
+        in_combat=False,
+        raw_state={"victory": True},
+    )
+    entries = (
+        ReplayEntry(
+            session_id="session-1",
+            step_index=0,
+            observation=encode_snapshot(terminal_snapshot),
+            terminal=True,
+            outcome="victory",
+        ),
+    )
+
+    assert LearnerTransitionExtractor().extract(entries) == ()
+
+
+def test_learner_mask_truncates_overflowing_hand_and_enemy_slots() -> None:
+    snapshot = make_combat_snapshot(
+        hand=tuple(make_card(name=f"Card {index}") for index in range(12)),
+        monsters=tuple(make_enemy(name=f"Enemy {index}") for index in range(6)),
+    )
+    encoded = LearnerObservationEncoder().encode(snapshot)
+
+    assert encoded.hand_mask == (1, 1, 1, 1, 1, 1, 1, 1, 1, 1)
+    assert encoded.enemy_mask == (1, 1, 1, 1, 1)


### PR DESCRIPTION
## Summary
- add a learner-facing training contract on top of the shared live rollout path
- encode live combat snapshots into a fixed 93-feature learner vector with explicit hand/enemy padding masks
- define a fixed 61-action combat index space, aligned legal-action masking, configurable shaped reward, and replay-to-transition extraction
- document the full learner contract and add focused training tests

## Contract
- observation vector size: 93
- action space size: 61
- mask semantics: fixed-length mask aligned to learner action indices; 1 means legal, 0 means illegal; transition tuples store the next-state mask for masked DQN bootstrap targets
- reward equation:
  reward =
    + enemy_hp_weight * max(0, enemy_hp(s) - enemy_hp(s'))
    - player_hp_weight * max(0, player_hp(s) - player_hp(s'))
    - step_penalty
    + terminal_win_bonus if victory
    - terminal_loss_penalty if defeat

## Validation
- ruff format .
- ruff check .
- pytest -q

## Risks
- card IDs and enemy intents are exposed as deterministic hashed numeric tokens rather than a learned vocabulary or one-hot basis
- learner actions outside the bounded MAX_HAND_SLOTS / MAX_ENEMIES window are intentionally unrepresentable and dropped from masks
