### PR TITLE
feat: add live masked DQN trainer loop

### DIFF
--- a/docs/live_training_scaffold.md
+++ b/docs/live_training_scaffold.md
@@ -3,7 +3,7 @@
 This scaffold turns the existing live rollout path into a lightweight
 experimentation substrate for data collection.
 
-### What It Does Today
+### Masked-DQN Trainer
 
 - defines explicit `ExperimentSpec` configs for live collection runs
 - runs repeated episodes through the existing `RolloutRunner` contract
@@ -14,12 +14,28 @@ experimentation substrate for data collection.
   `random_legal` policies can be used
 - exposes a matching CLI entrypoint through `scripts/run_live_experiment.py`
 
-### What It Does Not Do Yet
+### What It Does Today
 
-- no end-to-end RL optimizer or trainer loop
+In addition to collection-only experiments, the training package now includes a
+first end-to-end live masked-DQN baseline trainer:
+
+- `DQNTrainer`: runs live episodes through the shared `RolloutRunner`, extracts
+  learner-contract transitions, stores them in replay, samples mini-batches,
+  and optimizes an online Q-network against masked bootstrap targets
+- hard target-network syncs on a configurable cadence
+- greedy evaluation batches through the same live evaluation path
+- JSON metric summaries plus trainer checkpoints that include optimizer state,
+  replay contents, and trainer progress
+- a matching CLI entrypoint through `scripts/train_live_dqn.py`
+
+This is intentionally a minimal baseline. It is useful for plumbing,
+instrumentation, and debugging; it does not claim efficient live-game learning.
+
+### What It Still Does Not Do
+
 - no simulator-first training loop
-- no model registry beyond lightweight checkpoint helpers
-- no claim that end-to-end agent training exists today
+- no algorithm variants beyond a simple masked DQN baseline
+- no claim that live training is sample efficient or benchmark ready
 
 ### Masked-DQN Baseline Components
 
@@ -67,3 +83,24 @@ python scripts/run_live_experiment.py \
   --transport your_bridge_module:build_transport \
   --config configs/experiments/random_legal_collection.json
 ```
+
+## Minimal Trainer Example
+
+```bash
+python scripts/train_live_dqn.py \
+  --transport your_bridge_module:build_transport \
+  --output-dir artifacts/training/live_dqn_smoke \
+  --episodes 10 \
+  --evaluation-episodes 2 \
+  --warmup-steps 50 \
+  --batch-size 16 \
+  --target-update-frequency 20
+```
+
+The trainer writes:
+
+- `config.json`: validated trainer configuration
+- `metrics.jsonl`: one line per training episode
+- `evaluations.jsonl`: greedy evaluation summaries
+- `summary.json`: latest aggregate trainer summary
+- `checkpoints/`: periodic and final trainer checkpoints

--- a/scripts/train_live_dqn.py
+++ b/scripts/train_live_dqn.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Train a minimal masked-DQN baseline through the shared live rollout path."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from scripts._live_utils import build_live_episode_runner, instantiate_transport, load_object
+from sts_ironclad_rl.training import DQNTrainer, DQNTrainerConfig, EpsilonSchedule, MaskedDQNConfig
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--transport",
+        required=True,
+        help="Import path to a BridgeTransport factory, for example package.module:build_transport",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("artifacts/training/live_dqn"),
+        help="Directory for trainer config, metrics, summaries, and checkpoints",
+    )
+    parser.add_argument("--episodes", type=int, default=20, help="Training episodes to collect")
+    parser.add_argument(
+        "--evaluation-episodes",
+        type=int,
+        default=3,
+        help="Greedy evaluation episodes per evaluation batch",
+    )
+    parser.add_argument("--max-steps", type=int, default=200, help="Per-episode step cap")
+    parser.add_argument("--replay-size", type=int, default=10000, help="Replay buffer capacity")
+    parser.add_argument("--batch-size", type=int, default=32, help="Mini-batch size")
+    parser.add_argument("--learning-rate", type=float, default=1e-3, help="Adam learning rate")
+    parser.add_argument("--gamma", type=float, default=0.99, help="Discount factor")
+    parser.add_argument(
+        "--epsilon-start",
+        type=float,
+        default=1.0,
+        help="Initial epsilon for collection",
+    )
+    parser.add_argument(
+        "--epsilon-final",
+        type=float,
+        default=0.05,
+        help="Final epsilon after linear decay",
+    )
+    parser.add_argument(
+        "--epsilon-decay-steps",
+        type=int,
+        default=10000,
+        help="Environment steps used for linear epsilon decay",
+    )
+    parser.add_argument(
+        "--target-update-frequency",
+        type=int,
+        default=100,
+        help="Optimizer steps between hard target-network syncs",
+    )
+    parser.add_argument(
+        "--warmup-steps",
+        type=int,
+        default=1000,
+        help="Environment steps to collect before optimization starts",
+    )
+    parser.add_argument(
+        "--evaluation-cadence",
+        type=int,
+        default=10,
+        help="Training episodes between greedy evaluation batches",
+    )
+    parser.add_argument(
+        "--checkpoint-cadence",
+        type=int,
+        default=10,
+        help="Training episodes between checkpoint writes",
+    )
+    parser.add_argument(
+        "--hidden-sizes",
+        type=int,
+        nargs="+",
+        default=(128, 128),
+        help="MLP hidden layer sizes for the online and target networks",
+    )
+    parser.add_argument("--seed", type=int, default=None, help="Optional RNG seed")
+    parser.add_argument("--host", default="127.0.0.1", help="Bridge host forwarded to BridgeConfig")
+    parser.add_argument(
+        "--port", type=int, default=8080, help="Bridge port forwarded to BridgeConfig"
+    )
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    transport_factory = load_object(args.transport)
+    transport = instantiate_transport(transport_factory)
+    runner = build_live_episode_runner(
+        transport=transport,
+        host=args.host,
+        port=args.port,
+        max_steps=args.max_steps,
+    )
+    trainer = DQNTrainer(
+        rollout_runner=runner,
+        config=DQNTrainerConfig(
+            train_episodes=args.episodes,
+            evaluation_episodes=args.evaluation_episodes,
+            max_steps_per_episode=args.max_steps,
+            replay_buffer_size=args.replay_size,
+            batch_size=args.batch_size,
+            learning_rate=args.learning_rate,
+            gamma=args.gamma,
+            epsilon_schedule=EpsilonSchedule(
+                initial=args.epsilon_start,
+                final=args.epsilon_final,
+                decay_steps=args.epsilon_decay_steps,
+            ),
+            target_update_frequency=args.target_update_frequency,
+            warmup_steps=args.warmup_steps,
+            evaluation_cadence=args.evaluation_cadence,
+            checkpoint_cadence=args.checkpoint_cadence,
+            network=MaskedDQNConfig(hidden_sizes=tuple(args.hidden_sizes)),
+            seed=args.seed,
+        ),
+    )
+    result = trainer.train(output_dir=args.output_dir)
+    print(f"output_dir={result.output_dir}")
+    print(json.dumps(trainer.training_summary(), indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sts_ironclad_rl/training/__init__.py
+++ b/src/sts_ironclad_rl/training/__init__.py
@@ -35,6 +35,19 @@ from .learner import (
     RewardConfig,
 )
 from .specs import ExperimentSpec, load_experiment_spec
+from .trainer import (
+    DQNTrainer,
+    DQNTrainerConfig,
+    DQNTrainingResult,
+    EpsilonSchedule,
+    MaskedDQNPolicy,
+    PolicySelectionStats,
+    TrainerState,
+    TrainingEpisodeMetrics,
+    should_sync_target_network,
+    summarize_training_metrics,
+    transition_to_dict,
+)
 
 __all__ = [
     "ExperimentArtifactStore",
@@ -42,8 +55,12 @@ __all__ = [
     "ExperimentRunResult",
     "ExperimentRunner",
     "ExperimentSpec",
+    "DQNTrainer",
+    "DQNTrainerConfig",
+    "DQNTrainingResult",
     "DEFAULT_ACTION_SIZE",
     "DEFAULT_OBSERVATION_SIZE",
+    "EpsilonSchedule",
     "LEARNER_OBSERVATION_SCHEMA_VERSION",
     "LEARNER_TRANSITION_SCHEMA_VERSION",
     "LearnerActionIndex",
@@ -55,11 +72,15 @@ __all__ = [
     "LearnerTransitionExtractor",
     "MaskedDQN",
     "MaskedDQNConfig",
+    "MaskedDQNPolicy",
     "PolicyProvider",
+    "PolicySelectionStats",
     "ReplayBatch",
     "ReplayBuffer",
     "RewardConfig",
     "RunMetadata",
+    "TrainerState",
+    "TrainingEpisodeMetrics",
     "build_run_id",
     "epsilon_greedy_action",
     "legal_argmax",
@@ -68,5 +89,8 @@ __all__ = [
     "make_run_metadata",
     "sanitize_legal_action_mask",
     "save_checkpoint",
+    "should_sync_target_network",
     "slugify",
+    "summarize_training_metrics",
+    "transition_to_dict",
 ]

--- a/src/sts_ironclad_rl/training/trainer.py
+++ b/src/sts_ironclad_rl/training/trainer.py
@@ -1,0 +1,694 @@
+"""Masked-DQN trainer loop built on the shared live rollout path."""
+
+from __future__ import annotations
+
+import json
+import random
+from collections import Counter, deque
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from statistics import fmean
+from typing import Any
+
+import torch
+from torch import Tensor, nn
+
+from ..live import (
+    ActionDecision,
+    EncodedObservation,
+    EndTurnAction,
+    EvaluationCase,
+    EvaluationSummary,
+    PolicyEvaluator,
+    RolloutResult,
+    RolloutRunner,
+    summary_to_dict,
+)
+from .dqn import (
+    MaskedDQN,
+    MaskedDQNConfig,
+    ReplayBatch,
+    ReplayBuffer,
+    epsilon_greedy_action,
+    sanitize_legal_action_mask,
+)
+from .learner import LearnerActionIndex, LearnerObservationEncoder, LearnerTransitionExtractor
+
+
+@dataclass(frozen=True)
+class EpsilonSchedule:
+    """Linear epsilon schedule for exploration during collection."""
+
+    initial: float = 1.0
+    final: float = 0.05
+    decay_steps: int = 10_000
+
+    def __post_init__(self) -> None:
+        if not 0.0 <= self.final <= 1.0:
+            raise ValueError("final epsilon must be between 0 and 1")
+        if not 0.0 <= self.initial <= 1.0:
+            raise ValueError("initial epsilon must be between 0 and 1")
+        if self.final > self.initial:
+            raise ValueError("final epsilon must be less than or equal to initial epsilon")
+        if self.decay_steps <= 0:
+            raise ValueError("decay_steps must be positive")
+
+    def value(self, step: int) -> float:
+        """Return the scheduled epsilon for the provided environment step."""
+
+        if step <= 0:
+            return self.initial
+        progress = min(float(step) / float(self.decay_steps), 1.0)
+        return self.initial + ((self.final - self.initial) * progress)
+
+    def to_dict(self) -> dict[str, float | int]:
+        return {
+            "initial": self.initial,
+            "final": self.final,
+            "decay_steps": self.decay_steps,
+        }
+
+
+@dataclass(frozen=True)
+class DQNTrainerConfig:
+    """Configuration for a minimal live masked-DQN baseline."""
+
+    train_episodes: int = 20
+    evaluation_episodes: int = 3
+    max_steps_per_episode: int = 200
+    replay_buffer_size: int = 10_000
+    batch_size: int = 32
+    learning_rate: float = 1e-3
+    gamma: float = 0.99
+    epsilon_schedule: EpsilonSchedule = field(default_factory=EpsilonSchedule)
+    target_update_frequency: int = 100
+    warmup_steps: int = 1_000
+    evaluation_cadence: int = 10
+    checkpoint_cadence: int = 10
+    gradient_clip_norm: float | None = 10.0
+    metric_window_size: int = 20
+    seed: int | None = None
+    network: MaskedDQNConfig = field(default_factory=MaskedDQNConfig)
+    train_case_name: str = "dqn_train"
+    evaluation_case_name: str = "dqn_eval"
+
+    def __post_init__(self) -> None:
+        if self.train_episodes <= 0:
+            raise ValueError("train_episodes must be positive")
+        if self.evaluation_episodes <= 0:
+            raise ValueError("evaluation_episodes must be positive")
+        if self.max_steps_per_episode <= 0:
+            raise ValueError("max_steps_per_episode must be positive")
+        if self.replay_buffer_size <= 0:
+            raise ValueError("replay_buffer_size must be positive")
+        if self.batch_size <= 0:
+            raise ValueError("batch_size must be positive")
+        if self.batch_size > self.replay_buffer_size:
+            raise ValueError("batch_size must not exceed replay_buffer_size")
+        if self.learning_rate <= 0:
+            raise ValueError("learning_rate must be positive")
+        if not 0.0 <= self.gamma <= 1.0:
+            raise ValueError("gamma must be between 0 and 1")
+        if self.target_update_frequency <= 0:
+            raise ValueError("target_update_frequency must be positive")
+        if self.warmup_steps < 0:
+            raise ValueError("warmup_steps must be non-negative")
+        if self.evaluation_cadence <= 0:
+            raise ValueError("evaluation_cadence must be positive")
+        if self.checkpoint_cadence <= 0:
+            raise ValueError("checkpoint_cadence must be positive")
+        if self.gradient_clip_norm is not None and self.gradient_clip_norm <= 0:
+            raise ValueError("gradient_clip_norm must be positive when provided")
+        if self.metric_window_size <= 0:
+            raise ValueError("metric_window_size must be positive")
+        if not self.train_case_name.strip():
+            raise ValueError("train_case_name must not be empty")
+        if not self.evaluation_case_name.strip():
+            raise ValueError("evaluation_case_name must not be empty")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "train_episodes": self.train_episodes,
+            "evaluation_episodes": self.evaluation_episodes,
+            "max_steps_per_episode": self.max_steps_per_episode,
+            "replay_buffer_size": self.replay_buffer_size,
+            "batch_size": self.batch_size,
+            "learning_rate": self.learning_rate,
+            "gamma": self.gamma,
+            "epsilon_schedule": self.epsilon_schedule.to_dict(),
+            "target_update_frequency": self.target_update_frequency,
+            "warmup_steps": self.warmup_steps,
+            "evaluation_cadence": self.evaluation_cadence,
+            "checkpoint_cadence": self.checkpoint_cadence,
+            "gradient_clip_norm": self.gradient_clip_norm,
+            "metric_window_size": self.metric_window_size,
+            "seed": self.seed,
+            "network": {
+                "observation_size": self.network.observation_size,
+                "action_size": self.network.action_size,
+                "hidden_sizes": list(self.network.hidden_sizes),
+            },
+            "train_case_name": self.train_case_name,
+            "evaluation_case_name": self.evaluation_case_name,
+        }
+
+
+@dataclass(frozen=True)
+class PolicySelectionStats:
+    """Episode-local action-selection diagnostics."""
+
+    mask_fallback_count: int = 0
+    invalid_action_count: int = 0
+
+
+@dataclass(frozen=True)
+class TrainingEpisodeMetrics:
+    """Per-episode trainer metrics for logging and summaries."""
+
+    episode_index: int
+    environment_steps: int
+    optimization_steps: int
+    replay_size: int
+    epsilon: float
+    transition_count: int
+    episode_return: float
+    average_reward: float
+    average_loss: float | None
+    episode_length: int
+    outcome: str | None
+    terminal: bool
+    total_reward_proxy: float | None
+    mask_fallback_count: int
+    invalid_action_count: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class TrainerState:
+    """Mutable training progress serialized in checkpoints."""
+
+    completed_episodes: int = 0
+    environment_steps: int = 0
+    optimization_steps: int = 0
+    target_sync_steps: int = 0
+
+    def to_dict(self) -> dict[str, int]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class DQNTrainingResult:
+    """End-of-run trainer result."""
+
+    state: TrainerState
+    episode_metrics: tuple[TrainingEpisodeMetrics, ...]
+    evaluation_summaries: tuple[EvaluationSummary, ...]
+    output_dir: Path | None = None
+
+
+@dataclass(frozen=True)
+class MaskedDQNPolicy:
+    """Policy adapter from a Q-network to the shared live `Policy` contract."""
+
+    model: MaskedDQN
+    epsilon: float
+    device: torch.device
+    name: str = "masked_dqn"
+    observation_encoder: LearnerObservationEncoder = field(
+        default_factory=LearnerObservationEncoder
+    )
+    action_index: LearnerActionIndex = field(default_factory=LearnerActionIndex)
+    rng: random.Random = field(default_factory=random.Random, repr=False)
+    _mask_fallback_count: int = field(init=False, default=0, repr=False)
+    _invalid_action_count: int = field(init=False, default=0, repr=False)
+
+    def select_action(self, observation: EncodedObservation) -> ActionDecision:
+        state_vector = self.observation_encoder.encode(observation).vector
+        raw_mask = self.action_index.legal_mask(observation)
+        safe_mask = sanitize_legal_action_mask(raw_mask, action_size=self.action_index.size)
+        if tuple(int(value) for value in safe_mask.tolist()) != tuple(raw_mask):
+            object.__setattr__(self, "_mask_fallback_count", self._mask_fallback_count + 1)
+
+        with torch.no_grad():
+            q_values = self.model(
+                torch.tensor(state_vector, dtype=torch.float32, device=self.device)
+            ).detach()
+        safe_mask = safe_mask.to(device=q_values.device)
+        selected_index = epsilon_greedy_action(
+            q_values,
+            safe_mask,
+            epsilon=self.epsilon,
+            rng=self.rng,
+        )
+        action_id = self.action_index.index_to_action_id(selected_index)
+        if action_id not in observation.legal_action_ids:
+            object.__setattr__(self, "_invalid_action_count", self._invalid_action_count + 1)
+            action_id = _fallback_action_id(observation.legal_action_ids)
+
+        return ActionDecision(
+            action_id=action_id,
+            metadata={"action_index": selected_index, "epsilon": self.epsilon},
+        )
+
+    def stats(self) -> PolicySelectionStats:
+        return PolicySelectionStats(
+            mask_fallback_count=self._mask_fallback_count,
+            invalid_action_count=self._invalid_action_count,
+        )
+
+
+@dataclass
+class DQNTrainer:
+    """Collect live episodes, build replay, and optimize a masked-DQN baseline."""
+
+    rollout_runner: RolloutRunner
+    config: DQNTrainerConfig = field(default_factory=DQNTrainerConfig)
+    evaluation_runner: RolloutRunner | None = None
+    transition_extractor: LearnerTransitionExtractor = field(
+        default_factory=LearnerTransitionExtractor
+    )
+    device: torch.device | str = "cpu"
+    online_network: MaskedDQN | None = None
+    target_network: MaskedDQN | None = None
+    replay_buffer: ReplayBuffer | None = None
+
+    def __post_init__(self) -> None:
+        self.device = torch.device(self.device)
+        self._rng = random.Random(self.config.seed)
+        if self.config.seed is not None:
+            torch.manual_seed(self.config.seed)
+
+        self.online_network = self.online_network or MaskedDQN(self.config.network)
+        self.target_network = self.target_network or MaskedDQN(self.config.network)
+        self.online_network.to(self.device)
+        self.target_network.to(self.device)
+        self.target_network.load_state_dict(self.online_network.state_dict())
+        self.target_network.eval()
+
+        self.optimizer = torch.optim.Adam(
+            self.online_network.parameters(),
+            lr=self.config.learning_rate,
+        )
+        self.loss_fn: nn.Module = nn.MSELoss()
+        self.replay_buffer = self.replay_buffer or ReplayBuffer(self.config.replay_buffer_size)
+        self.state = TrainerState()
+        self._episode_metrics: list[TrainingEpisodeMetrics] = []
+        self._evaluation_summaries: list[EvaluationSummary] = []
+        self._recent_metrics: deque[TrainingEpisodeMetrics] = deque(
+            maxlen=self.config.metric_window_size
+        )
+
+    def train(self, *, output_dir: Path | None = None) -> DQNTrainingResult:
+        """Run the configured number of live episodes through the trainer loop."""
+
+        output_paths = _TrainerOutputPaths.create(output_dir) if output_dir is not None else None
+        if output_paths is not None:
+            _write_json(output_paths.config_path, self.config.to_dict())
+
+        for _ in range(self.config.train_episodes):
+            episode_index = self.state.completed_episodes
+            epsilon = self.config.epsilon_schedule.value(self.state.environment_steps)
+            policy = MaskedDQNPolicy(
+                model=self.online_network,
+                epsilon=epsilon,
+                device=self.device,
+                rng=self._rng,
+            )
+            result = self.rollout_runner.run_episode(
+                policy=policy,
+                evaluation_case=EvaluationCase(
+                    name=self.config.train_case_name,
+                    max_steps=self.config.max_steps_per_episode,
+                ),
+            )
+            metrics = self._consume_rollout(
+                episode_index=episode_index,
+                epsilon=epsilon,
+                result=result,
+                policy_stats=policy.stats(),
+            )
+            self._episode_metrics.append(metrics)
+            self._recent_metrics.append(metrics)
+            self.state = TrainerState(
+                completed_episodes=self.state.completed_episodes + 1,
+                environment_steps=self.state.environment_steps,
+                optimization_steps=self.state.optimization_steps,
+                target_sync_steps=self.state.target_sync_steps,
+            )
+
+            if output_paths is not None:
+                _append_jsonl(output_paths.metrics_path, metrics.to_dict())
+                _write_json(output_paths.summary_path, self.training_summary())
+
+            if self.state.completed_episodes % self.config.evaluation_cadence == 0:
+                evaluation_summary = self.evaluate()
+                self._evaluation_summaries.append(evaluation_summary)
+                if output_paths is not None:
+                    _append_jsonl(
+                        output_paths.evaluations_path, summary_to_dict(evaluation_summary)
+                    )
+
+            if output_paths is not None and (
+                self.state.completed_episodes % self.config.checkpoint_cadence == 0
+            ):
+                self.save_checkpoint(
+                    output_paths.checkpoints_dir
+                    / f"checkpoint_ep{self.state.completed_episodes:06d}.pt"
+                )
+
+        if output_paths is not None:
+            self.save_checkpoint(output_paths.checkpoints_dir / "checkpoint_final.pt")
+            _write_json(output_paths.summary_path, self.training_summary())
+
+        return DQNTrainingResult(
+            state=self.state,
+            episode_metrics=tuple(self._episode_metrics),
+            evaluation_summaries=tuple(self._evaluation_summaries),
+            output_dir=output_dir,
+        )
+
+    def evaluate(self) -> EvaluationSummary:
+        """Run a greedy evaluation batch through the shared rollout path."""
+
+        evaluator = PolicyEvaluator(runner=self.evaluation_runner or self.rollout_runner)
+        policy = MaskedDQNPolicy(
+            model=self.online_network,
+            epsilon=0.0,
+            device=self.device,
+            name="masked_dqn_eval",
+            rng=random.Random(self.config.seed),
+        )
+        return evaluator.evaluate(
+            policy=policy,
+            episode_count=self.config.evaluation_episodes,
+            evaluation_case=EvaluationCase(
+                name=self.config.evaluation_case_name,
+                max_steps=self.config.max_steps_per_episode,
+            ),
+        ).summary
+
+    def training_summary(self) -> dict[str, Any]:
+        """Return a compact JSON-serializable training summary."""
+
+        recent_summary = summarize_training_metrics(tuple(self._recent_metrics))
+        return {
+            "state": self.state.to_dict(),
+            "replay_size": len(self.replay_buffer),
+            "recent_metrics": recent_summary,
+            "evaluation_count": len(self._evaluation_summaries),
+        }
+
+    def save_checkpoint(
+        self,
+        path: str | Path,
+        *,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        """Persist trainer state, optimizer state, and replay contents."""
+
+        checkpoint_path = Path(path)
+        checkpoint_path.parent.mkdir(parents=True, exist_ok=True)
+        torch.save(
+            {
+                "config": self.config.to_dict(),
+                "trainer_state": self.state.to_dict(),
+                "online_model_state_dict": self.online_network.state_dict(),
+                "target_model_state_dict": self.target_network.state_dict(),
+                "optimizer_state_dict": self.optimizer.state_dict(),
+                "replay": [transition_to_dict(item) for item in self.replay_buffer.transitions()],
+                "metadata": {
+                    **self.training_summary(),
+                    **dict(metadata or {}),
+                },
+            },
+            checkpoint_path,
+        )
+
+    def load_checkpoint(
+        self,
+        path: str | Path,
+        *,
+        map_location: torch.device | str | None = "cpu",
+    ) -> dict[str, Any]:
+        """Restore trainer progress from a checkpoint and return its metadata."""
+
+        payload = torch.load(Path(path), map_location=map_location, weights_only=False)
+        if not isinstance(payload, dict):
+            raise ValueError("checkpoint payload must be a dictionary")
+
+        self.online_network.load_state_dict(payload["online_model_state_dict"])
+        self.target_network.load_state_dict(payload["target_model_state_dict"])
+        self.optimizer.load_state_dict(payload["optimizer_state_dict"])
+
+        trainer_state = payload.get("trainer_state")
+        if not isinstance(trainer_state, dict):
+            raise ValueError("checkpoint trainer_state must be a dictionary")
+        self.state = TrainerState(
+            completed_episodes=int(trainer_state["completed_episodes"]),
+            environment_steps=int(trainer_state["environment_steps"]),
+            optimization_steps=int(trainer_state["optimization_steps"]),
+            target_sync_steps=int(trainer_state["target_sync_steps"]),
+        )
+
+        replay_items = payload.get("replay", [])
+        if not isinstance(replay_items, list):
+            raise ValueError("checkpoint replay must be a list")
+        self.replay_buffer = ReplayBuffer(self.config.replay_buffer_size)
+        for item in replay_items:
+            self.replay_buffer.append(**item)
+
+        metadata = payload.get("metadata", {})
+        if not isinstance(metadata, dict):
+            raise ValueError("checkpoint metadata must be a dictionary")
+        return metadata
+
+    def _consume_rollout(
+        self,
+        *,
+        episode_index: int,
+        epsilon: float,
+        result: RolloutResult,
+        policy_stats: PolicySelectionStats,
+    ) -> TrainingEpisodeMetrics:
+        transitions = self.transition_extractor.extract(result.entries)
+        losses: list[float] = []
+        for transition in transitions:
+            self.replay_buffer.append_transition(transition)
+            self.state = TrainerState(
+                completed_episodes=self.state.completed_episodes,
+                environment_steps=self.state.environment_steps + 1,
+                optimization_steps=self.state.optimization_steps,
+                target_sync_steps=self.state.target_sync_steps,
+            )
+            loss = self._maybe_optimize()
+            if loss is not None:
+                losses.append(loss)
+
+        episode_return = float(sum(transition.reward for transition in transitions))
+        average_reward = episode_return / len(transitions) if transitions else 0.0
+        return TrainingEpisodeMetrics(
+            episode_index=episode_index,
+            environment_steps=self.state.environment_steps,
+            optimization_steps=self.state.optimization_steps,
+            replay_size=len(self.replay_buffer),
+            epsilon=epsilon,
+            transition_count=len(transitions),
+            episode_return=episode_return,
+            average_reward=average_reward,
+            average_loss=fmean(losses) if losses else None,
+            episode_length=result.step_count,
+            outcome=result.outcome,
+            terminal=result.terminal,
+            total_reward_proxy=result.total_reward,
+            mask_fallback_count=policy_stats.mask_fallback_count,
+            invalid_action_count=policy_stats.invalid_action_count,
+        )
+
+    def _maybe_optimize(self) -> float | None:
+        if self.state.environment_steps < self.config.warmup_steps:
+            return None
+        if len(self.replay_buffer) < self.config.batch_size:
+            return None
+
+        batch = self.replay_buffer.sample(
+            self.config.batch_size,
+            rng=self._rng,
+            device=self.device,
+        )
+        loss = self._optimize_batch(batch)
+        next_optimization_steps = self.state.optimization_steps + 1
+        next_target_syncs = self.state.target_sync_steps
+        if should_sync_target_network(
+            optimization_steps=next_optimization_steps,
+            target_update_frequency=self.config.target_update_frequency,
+        ):
+            self.target_network.load_state_dict(self.online_network.state_dict())
+            next_target_syncs += 1
+        self.state = TrainerState(
+            completed_episodes=self.state.completed_episodes,
+            environment_steps=self.state.environment_steps,
+            optimization_steps=next_optimization_steps,
+            target_sync_steps=next_target_syncs,
+        )
+        return loss
+
+    def _optimize_batch(self, batch: ReplayBatch) -> float:
+        self.online_network.train()
+        q_values = self.online_network(batch.observations)
+        chosen_q_values = q_values.gather(1, batch.actions.unsqueeze(1)).squeeze(1)
+
+        with torch.no_grad():
+            next_q_values = self.target_network(batch.next_observations)
+            next_action_values = _masked_next_q_values(
+                next_q_values,
+                batch.legal_action_masks,
+            )
+            targets = batch.rewards + (
+                (~batch.dones).to(dtype=torch.float32) * self.config.gamma * next_action_values
+            )
+
+        loss = self.loss_fn(chosen_q_values, targets)
+        self.optimizer.zero_grad()
+        loss.backward()
+        if self.config.gradient_clip_norm is not None:
+            torch.nn.utils.clip_grad_norm_(
+                self.online_network.parameters(),
+                max_norm=self.config.gradient_clip_norm,
+            )
+        self.optimizer.step()
+        self.online_network.eval()
+        return float(loss.item())
+
+
+@dataclass(frozen=True)
+class _TrainerOutputPaths:
+    root_dir: Path
+    config_path: Path
+    metrics_path: Path
+    evaluations_path: Path
+    summary_path: Path
+    checkpoints_dir: Path
+
+    @classmethod
+    def create(cls, root_dir: Path) -> _TrainerOutputPaths:
+        root_dir.mkdir(parents=True, exist_ok=True)
+        checkpoints_dir = root_dir / "checkpoints"
+        checkpoints_dir.mkdir(parents=True, exist_ok=True)
+        return cls(
+            root_dir=root_dir,
+            config_path=root_dir / "config.json",
+            metrics_path=root_dir / "metrics.jsonl",
+            evaluations_path=root_dir / "evaluations.jsonl",
+            summary_path=root_dir / "summary.json",
+            checkpoints_dir=checkpoints_dir,
+        )
+
+
+def should_sync_target_network(
+    *,
+    optimization_steps: int,
+    target_update_frequency: int,
+) -> bool:
+    """Return whether a hard target-network sync is due on this optimizer step."""
+
+    if optimization_steps <= 0:
+        return False
+    if target_update_frequency <= 0:
+        raise ValueError("target_update_frequency must be positive")
+    return optimization_steps % target_update_frequency == 0
+
+
+def summarize_training_metrics(
+    metrics: tuple[TrainingEpisodeMetrics, ...],
+) -> dict[str, Any]:
+    """Aggregate recent episode metrics into a compact summary payload."""
+
+    if not metrics:
+        return {
+            "episode_count": 0,
+            "average_loss": None,
+            "average_reward": None,
+            "average_episode_return": None,
+            "average_episode_length": None,
+            "epsilon": None,
+            "outcomes": {},
+            "mask_fallback_count": 0,
+            "invalid_action_count": 0,
+        }
+
+    average_losses = [item.average_loss for item in metrics if item.average_loss is not None]
+    return {
+        "episode_count": len(metrics),
+        "average_loss": fmean(average_losses) if average_losses else None,
+        "average_reward": fmean(item.average_reward for item in metrics),
+        "average_episode_return": fmean(item.episode_return for item in metrics),
+        "average_episode_length": fmean(float(item.episode_length) for item in metrics),
+        "epsilon": metrics[-1].epsilon,
+        "outcomes": dict(sorted(Counter(item.outcome or "unknown" for item in metrics).items())),
+        "mask_fallback_count": sum(item.mask_fallback_count for item in metrics),
+        "invalid_action_count": sum(item.invalid_action_count for item in metrics),
+    }
+
+
+def transition_to_dict(transition) -> dict[str, Any]:
+    """Return a JSON- and checkpoint-serializable learner transition payload."""
+
+    return {
+        "state": list(transition.state),
+        "action_index": transition.action_index,
+        "reward": transition.reward,
+        "next_state": list(transition.next_state),
+        "done": transition.done,
+        "mask": list(transition.mask),
+    }
+
+
+def _masked_next_q_values(q_values: Tensor, legal_action_masks: Tensor) -> Tensor:
+    safe_masks = _sanitize_batch_masks(legal_action_masks, action_size=q_values.shape[1])
+    masked_q_values = q_values.masked_fill(~safe_masks, float("-inf"))
+    return masked_q_values.max(dim=1).values
+
+
+def _sanitize_batch_masks(legal_action_masks: Tensor, *, action_size: int) -> Tensor:
+    masks = legal_action_masks.to(dtype=torch.bool)
+    if masks.ndim != 2 or masks.shape[1] != action_size:
+        raise ValueError("legal_action_masks must be rank 2 with one row per action vector")
+    sanitized = masks.clone()
+    invalid_rows = ~sanitized.any(dim=1)
+    sanitized[invalid_rows, 0] = True
+    return sanitized
+
+
+def _fallback_action_id(legal_action_ids: tuple[str, ...]) -> str:
+    if EndTurnAction().action_id in legal_action_ids:
+        return EndTurnAction().action_id
+    if not legal_action_ids:
+        raise ValueError("legal_action_ids must not be empty")
+    return legal_action_ids[0]
+
+
+def _append_jsonl(path: Path, payload: dict[str, Any]) -> None:
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, sort_keys=True))
+        handle.write("\n")
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+__all__ = [
+    "DQNTrainer",
+    "DQNTrainerConfig",
+    "DQNTrainingResult",
+    "EpsilonSchedule",
+    "MaskedDQNPolicy",
+    "PolicySelectionStats",
+    "TrainerState",
+    "TrainingEpisodeMetrics",
+    "should_sync_target_network",
+    "summarize_training_metrics",
+    "transition_to_dict",
+]

--- a/tests/training/test_trainer.py
+++ b/tests/training/test_trainer.py
@@ -1,0 +1,328 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pytest
+import torch
+
+from sts_ironclad_rl.integration import GameStateSnapshot
+from sts_ironclad_rl.live import (
+    ActionDecision,
+    BridgeObservationEncoder,
+    EndTurnAction,
+    PlayCardAction,
+    ReplayEntry,
+    RolloutResult,
+)
+from sts_ironclad_rl.training import (
+    DQNTrainer,
+    DQNTrainerConfig,
+    EpsilonSchedule,
+    MaskedDQNConfig,
+    TrainerState,
+    TrainingEpisodeMetrics,
+    should_sync_target_network,
+    summarize_training_metrics,
+)
+
+
+@dataclass
+class StaticRolloutRunner:
+    results: list[RolloutResult]
+    calls: int = field(init=False, default=0)
+
+    def run_episode(self, *, policy, evaluation_case=None) -> RolloutResult:
+        del policy, evaluation_case
+        index = min(self.calls, len(self.results) - 1)
+        self.calls += 1
+        return self.results[index]
+
+
+def test_epsilon_schedule_decays_linearly_and_clamps() -> None:
+    schedule = EpsilonSchedule(initial=1.0, final=0.2, decay_steps=100)
+
+    assert schedule.value(0) == pytest.approx(1.0)
+    assert schedule.value(25) == pytest.approx(0.8)
+    assert schedule.value(100) == pytest.approx(0.2)
+    assert schedule.value(200) == pytest.approx(0.2)
+
+
+def test_trainer_config_rejects_invalid_values() -> None:
+    with pytest.raises(ValueError, match="batch_size must not exceed replay_buffer_size"):
+        DQNTrainerConfig(replay_buffer_size=4, batch_size=5)
+    with pytest.raises(ValueError, match="target_update_frequency must be positive"):
+        DQNTrainerConfig(target_update_frequency=0)
+    with pytest.raises(ValueError, match="gamma must be between 0 and 1"):
+        DQNTrainerConfig(gamma=1.5)
+
+
+def test_target_sync_cadence_helper() -> None:
+    assert should_sync_target_network(optimization_steps=1, target_update_frequency=2) is False
+    assert should_sync_target_network(optimization_steps=2, target_update_frequency=2) is True
+    assert should_sync_target_network(optimization_steps=4, target_update_frequency=2) is True
+
+
+def test_trainer_runs_update_loop_with_replay_backed_transitions(tmp_path) -> None:
+    trainer = DQNTrainer(
+        rollout_runner=StaticRolloutRunner(results=[make_rollout_result()]),
+        config=DQNTrainerConfig(
+            train_episodes=1,
+            evaluation_cadence=10,
+            checkpoint_cadence=10,
+            evaluation_episodes=1,
+            replay_buffer_size=8,
+            batch_size=2,
+            warmup_steps=0,
+            target_update_frequency=1,
+            network=MaskedDQNConfig(hidden_sizes=(8,)),
+            seed=7,
+        ),
+    )
+    initial_parameters = [
+        parameter.detach().clone() for parameter in trainer.online_network.parameters()
+    ]
+
+    result = trainer.train(output_dir=tmp_path)
+
+    assert result.state == TrainerState(
+        completed_episodes=1,
+        environment_steps=2,
+        optimization_steps=1,
+        target_sync_steps=1,
+    )
+    assert len(trainer.replay_buffer) == 2
+    assert result.episode_metrics[0].episode_return != 0.0
+    assert (tmp_path / "config.json").exists()
+    assert (tmp_path / "summary.json").exists()
+    assert (tmp_path / "checkpoints" / "checkpoint_final.pt").exists()
+    assert any(
+        not torch.equal(before, after.detach())
+        for before, after in zip(
+            initial_parameters, trainer.online_network.parameters(), strict=True
+        )
+    )
+
+
+def test_trainer_checkpoint_restores_progress_and_replay(tmp_path) -> None:
+    config = DQNTrainerConfig(
+        train_episodes=1,
+        evaluation_cadence=10,
+        checkpoint_cadence=10,
+        evaluation_episodes=1,
+        replay_buffer_size=8,
+        batch_size=2,
+        warmup_steps=0,
+        network=MaskedDQNConfig(hidden_sizes=(8,)),
+        seed=11,
+    )
+    trainer = DQNTrainer(
+        rollout_runner=StaticRolloutRunner(results=[make_rollout_result()]),
+        config=config,
+    )
+    trainer.train()
+    checkpoint_path = tmp_path / "trainer.pt"
+    trainer.save_checkpoint(checkpoint_path, metadata={"label": "resume-test"})
+
+    restored = DQNTrainer(
+        rollout_runner=StaticRolloutRunner(results=[make_rollout_result()]),
+        config=config,
+    )
+    metadata = restored.load_checkpoint(checkpoint_path)
+
+    assert metadata["label"] == "resume-test"
+    assert metadata["state"] == trainer.training_summary()["state"]
+    assert restored.state == trainer.state
+    assert len(restored.replay_buffer) == len(trainer.replay_buffer)
+
+
+def test_training_metric_summary_aggregates_recent_window() -> None:
+    summary = summarize_training_metrics(
+        (
+            TrainingEpisodeMetrics(
+                episode_index=0,
+                environment_steps=3,
+                optimization_steps=1,
+                replay_size=3,
+                epsilon=0.9,
+                transition_count=3,
+                episode_return=1.5,
+                average_reward=0.5,
+                average_loss=0.2,
+                episode_length=3,
+                outcome="victory",
+                terminal=True,
+                total_reward_proxy=1.0,
+                mask_fallback_count=1,
+                invalid_action_count=0,
+            ),
+            TrainingEpisodeMetrics(
+                episode_index=1,
+                environment_steps=6,
+                optimization_steps=2,
+                replay_size=6,
+                epsilon=0.8,
+                transition_count=3,
+                episode_return=0.3,
+                average_reward=0.1,
+                average_loss=0.4,
+                episode_length=4,
+                outcome="defeat",
+                terminal=True,
+                total_reward_proxy=-1.0,
+                mask_fallback_count=0,
+                invalid_action_count=2,
+            ),
+        )
+    )
+
+    assert summary["episode_count"] == 2
+    assert summary["average_loss"] == pytest.approx(0.3)
+    assert summary["average_reward"] == pytest.approx(0.3)
+    assert summary["average_episode_return"] == pytest.approx(0.9)
+    assert summary["average_episode_length"] == pytest.approx(3.5)
+    assert summary["outcomes"] == {"defeat": 1, "victory": 1}
+    assert summary["mask_fallback_count"] == 1
+    assert summary["invalid_action_count"] == 2
+    assert summary["epsilon"] == pytest.approx(0.8)
+
+
+def make_rollout_result() -> RolloutResult:
+    play_action = PlayCardAction(hand_index=0).action_id
+    end_turn = EndTurnAction().action_id
+
+    first_snapshot = make_combat_snapshot(
+        available_actions=(play_action, end_turn),
+        hand=(make_card(name="Strike", has_target=False),),
+        monsters=(make_enemy(current_hp=18, max_hp=18),),
+    )
+    second_snapshot = make_combat_snapshot(
+        available_actions=(end_turn,),
+        turn=2,
+        player={"current_hp": 70, "max_hp": 80, "block": 0, "energy": 2},
+        hand=(),
+        monsters=(make_enemy(current_hp=12, max_hp=18),),
+    )
+    terminal_snapshot = make_snapshot(
+        available_actions=(),
+        screen_state="MAP",
+        in_combat=False,
+        raw_state={"victory": True},
+    )
+
+    return RolloutResult(
+        session_id="session-1",
+        entries=(
+            ReplayEntry(
+                session_id="session-1",
+                step_index=0,
+                observation=encode_snapshot(first_snapshot),
+                action=ActionDecision(action_id=play_action),
+            ),
+            ReplayEntry(
+                session_id="session-1",
+                step_index=1,
+                observation=encode_snapshot(second_snapshot),
+                action=ActionDecision(action_id=end_turn),
+            ),
+            ReplayEntry(
+                session_id="session-1",
+                step_index=2,
+                observation=encode_snapshot(terminal_snapshot),
+                terminal=True,
+                outcome="victory",
+            ),
+        ),
+        terminal=True,
+        step_count=2,
+        outcome="victory",
+        total_reward=1.0,
+    )
+
+
+def make_snapshot(
+    *,
+    session_id: str = "session-1",
+    screen_state: str = "COMBAT",
+    available_actions: tuple[str, ...] = (),
+    in_combat: bool = True,
+    floor: int | None = 3,
+    act: int | None = 1,
+    raw_state: dict[str, object] | None = None,
+) -> GameStateSnapshot:
+    return GameStateSnapshot(
+        session_id=session_id,
+        screen_state=screen_state,
+        available_actions=available_actions,
+        in_combat=in_combat,
+        floor=floor,
+        act=act,
+        raw_state={} if raw_state is None else dict(raw_state),
+    )
+
+
+def make_combat_snapshot(
+    *,
+    session_id: str = "session-1",
+    available_actions: tuple[str, ...] = (),
+    turn: int = 1,
+    player: dict[str, object] | None = None,
+    hand: tuple[dict[str, object], ...] = (),
+    monsters: tuple[dict[str, object], ...] = (),
+    extra_raw_state: dict[str, object] | None = None,
+) -> GameStateSnapshot:
+    raw_state: dict[str, object] = {
+        "combat_state": {
+            "turn": turn,
+            "player": player or {"current_hp": 70, "max_hp": 80, "block": 0, "energy": 3},
+            "hand": [dict(card) for card in hand],
+            "monsters": [dict(monster) for monster in monsters],
+        }
+    }
+    if extra_raw_state is not None:
+        raw_state.update(extra_raw_state)
+    return make_snapshot(
+        session_id=session_id,
+        available_actions=available_actions,
+        in_combat=True,
+        raw_state=raw_state,
+    )
+
+
+def make_card(
+    *,
+    name: str,
+    cost: int = 1,
+    is_playable: bool = True,
+    has_target: bool = False,
+) -> dict[str, object]:
+    return {
+        "name": name,
+        "id": name.lower(),
+        "cost": cost,
+        "is_playable": is_playable,
+        "has_target": has_target,
+    }
+
+
+def make_enemy(
+    *,
+    current_hp: int,
+    max_hp: int,
+    intent: str | None = None,
+) -> dict[str, object]:
+    return {
+        "name": "Louse",
+        "id": "louse",
+        "current_hp": current_hp,
+        "max_hp": max_hp,
+        "block": 0,
+        "intent": intent,
+        "intent_base_damage": 0,
+        "intent_hits": 1,
+        "is_gone": False,
+        "half_dead": False,
+    }
+
+
+def encode_snapshot(snapshot: GameStateSnapshot):
+    return BridgeObservationEncoder().encode(snapshot)


### PR DESCRIPTION
## Summary
- add a first real `DQNTrainer` loop on top of the shared live rollout path and frozen learner contract
- collect live episodes through the existing runner, extract learner transitions into replay, sample mini-batches, optimize an online Q-network, and hard-sync a target network on a fixed cadence
- add trainer checkpointing, JSON metric reporting, a live training CLI entrypoint, docs, and focused trainer tests

## Trainer Flow
- `DQNTrainer` runs training episodes through the existing `RolloutRunner` contract; it does not create a second control loop
- each episode uses `MaskedDQNPolicy`, which converts the shared encoded observation into the frozen 93-dim learner vector and selects one legal action from the frozen 61-action index space with epsilon-greedy exploration
- replay entries from the live rollout are converted by `LearnerTransitionExtractor` into `(s, a, r, s', done, next_mask)` tuples aligned with PR #30
- transitions are appended to `ReplayBuffer`; after warm-up and once replay has enough samples, the trainer draws mini-batches and computes masked DQN TD targets with the target network
- target-network syncs are hard updates on `target_update_frequency`; greedy evaluation batches run through the existing live evaluation path

## Key Configs
- replay buffer size
- batch size
- learning rate
- gamma
- linear epsilon schedule (`initial`, `final`, `decay_steps`)
- target update frequency
- warm-up steps before optimization
- evaluation cadence and evaluation episode count
- checkpoint cadence
- max steps per episode, seed, gradient clip norm, and MLP hidden sizes

## Metrics And Checkpoints
- per-episode metrics include loss, average shaped reward, episode return, episode length, epsilon, terminal outcome, and mask / invalid-action fallback counts
- `training_summary()` exposes rolling aggregate metrics and trainer progress
- trainer checkpoints save online/target network weights, optimizer state, replay contents, trainer counters, and summary metadata
- `scripts/train_live_dqn.py` provides a minimal CLI for running the trainer against the same live bridge transport used by the existing rollout tools

## Integration Notes
- rollout collection still goes through `LiveEpisodeRunner`
- transition extraction still goes through `LearnerTransitionExtractor`
- evaluation still goes through `PolicyEvaluator`
- no learner-contract changes were required; the trainer consumes the PR #30 observation size, action size, next-state mask semantics, and reward definition as-is

## Recommended First Experiment Settings
- `--episodes 10`
- `--evaluation-episodes 2`
- `--warmup-steps 50`
- `--batch-size 16`
- `--replay-size 1000`
- `--target-update-frequency 20`
- `--epsilon-start 1.0`
- `--epsilon-final 0.10`
- `--epsilon-decay-steps 500`

These settings are intentionally small for smoke runs through the live game path. They are for debugging trainer plumbing and checkpoint / metric behavior, not for claiming meaningful sample efficiency.

## Validation
- `ruff format .`
- `ruff check .`
- `pytest -q`

## Risks
- trainer checkpoints currently persist full replay contents, which is correct for resumability but can grow quickly for longer live runs
- the baseline uses hard target syncs and a simple MLP only; this is a correctness-first trainer, not an optimized live-learning stack
- live training remains bridge- and game-speed-bound, so reported metrics should be treated as instrumentation rather than evidence of efficient learning
